### PR TITLE
fix: force IPv4-only HTTP client to resolve socket connection issues

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,18 +1,44 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 )
 
 func CreateAuthenticatedClient(teamID, pdcpApiKey string) (*http.Client, error) {
+	// Create a custom dialer that forces IPv4 only
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
 		ForceAttemptHTTP2: true,
+		// Custom dial function that forces IPv4 only
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// Force IPv4 by changing network type
+			if network == "tcp" {
+				network = "tcp4"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+		// Connection management settings to prevent socket issues
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableKeepAlives:     false,
+		MaxIdleConnsPerHost:   10,
+		// Add response header timeout to prevent hanging connections
+		ResponseHeaderTimeout: 30 * time.Second,
 	}
 
 	proxyURL := os.Getenv("PROXY_URL")
@@ -26,6 +52,8 @@ func CreateAuthenticatedClient(teamID, pdcpApiKey string) (*http.Client, error) 
 
 	client := &http.Client{
 		Transport: transport,
+		// Add overall request timeout to prevent hanging requests
+		Timeout: 60 * time.Second,
 	}
 
 	// Create a custom RoundTripper to add headers to every request


### PR DESCRIPTION
- Add custom DialContext that forces tcp4 protocol to prevent IPv6 connectivity issues
- Implement proper connection timeouts and management settings
- Add response header timeout to prevent hanging connections
- Set overall client timeout to 60 seconds
- Configure connection pooling with MaxIdleConns and IdleConnTimeout

This resolves 'write tcp [IPv6]:port->[IPv6]:443: socket is not connected' errors that occur on systems with problematic IPv6 routing configurations.

Closes #119 