### PR TITLE
feat: configurable enumeration ports for naabu

### DIFF
--- a/cmd/pd-agent/main.go
+++ b/cmd/pd-agent/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	json "github.com/json-iterator/go"
 	"io"
 	"log/slog"
 	"net"
@@ -24,6 +23,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -1294,7 +1295,7 @@ func (r *Runner) processJetStreamEnumeration(ctx context.Context, work *natsrpc.
 						steps = strings.Split(enrichmentSteps, ",")
 					}
 				}
-				r.executeEnumeration(ctx, work.ScanID, chunk.ChunkID, steps, chunk.Targets)
+				r.executeEnumeration(ctx, work.ScanID, chunk.ChunkID, steps, chunk.Targets, work.EnumerationPorts)
 				return nil
 			},
 		)
@@ -1682,8 +1683,8 @@ func (r *Runner) executeNucleiScan(ctx context.Context, scanID, metaID, config, 
 }
 
 // executeEnumeration runs an enumeration chunk through pkg.Run.
-func (r *Runner) executeEnumeration(ctx context.Context, enumID, metaID string, steps, assets []string) {
-	r.logHelper("INFO", fmt.Sprintf("Starting enumeration for enumID=%s, metaID=%s, steps=%d, assets=%d", enumID, metaID, len(steps), len(assets)))
+func (r *Runner) executeEnumeration(ctx context.Context, enumID, metaID string, steps, assets []string, ports string) {
+	r.logHelper("INFO", fmt.Sprintf("Starting enumeration for enumID=%s, metaID=%s, steps=%d, assets=%d, ports=%s", enumID, metaID, len(steps), len(assets), ports))
 
 	var outputDir string
 	if r.options.AgentOutput != "" {
@@ -1694,12 +1695,13 @@ func (r *Runner) executeEnumeration(ctx context.Context, enumID, metaID string, 
 	task := &types.Task{
 		Tool: types.Nuclei,
 		Options: types.Options{
-			Hosts:         assets,
-			Steps:         steps,
-			Silent:        true,
-			EnumerationID: enumID,
-			TeamID:        r.options.TeamID,
-			Output:        outputDir,
+			Hosts:            assets,
+			Steps:            steps,
+			Silent:           true,
+			EnumerationID:    enumID,
+			TeamID:           r.options.TeamID,
+			Output:           outputDir,
+			EnumerationPorts: ports,
 		},
 		Id: metaID,
 	}

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -64,11 +64,16 @@ func Run(ctx context.Context, task *types.Task) (*types.TaskResult, []string, er
 		var hostsWithOpenPorts []string
 		if sliceutil.Contains(steps, "port_scan") {
 			serviceVersion := sliceutil.Contains(steps, "ports_service_scan")
+			ports := task.Options.EnumerationPorts
+			if ports == "" {
+				ports = "top-100"
+			}
 			of, err := runEmbeddedTool(ctx, task, "naabu", func(ctx context.Context, outputFile string) error {
 				_, err := runtools.RunNaabu(ctx, hosts, runtools.NaabuOptions{
 					OutputFile:        outputFile,
 					SkipHostDiscovery: true,
 					ServiceVersion:    serviceVersion,
+					Ports:             ports,
 				})
 				// naabu returns an error when no ports are found; downstream
 				// steps short-circuit on an empty hostsWithOpenPorts list.

--- a/pkg/natsrpc/types.go
+++ b/pkg/natsrpc/types.go
@@ -151,15 +151,16 @@ type RuntimeInfo struct {
 // work and chunks share a single group-level stream; consumers scope reads
 // via FilterSubject.
 type WorkMessage struct {
-	Type          string   `json:"type"`           // "scan" or "enumeration"
-	ScanID        string   `json:"scan_id"`        // scan_id or enumeration_id
-	ChunkSubject  string   `json:"chunk_subject"`  // subject filter for chunks
-	ChunkConsumer string   `json:"chunk_consumer"` // shared consumer name
-	ChunkCount    int      `json:"chunk_count,omitempty"`
-	Config        string   `json:"config,omitempty"`        // base64 scan configuration
-	ReportConfig  string   `json:"report_config,omitempty"` // base64 nuclei reporting (-rc) configuration
-	HistoryID     int64    `json:"history_id,omitempty"`
-	Steps         []string `json:"steps,omitempty"` // enumeration steps
+	Type             string   `json:"type"`           // "scan" or "enumeration"
+	ScanID           string   `json:"scan_id"`        // scan_id or enumeration_id
+	ChunkSubject     string   `json:"chunk_subject"`  // subject filter for chunks
+	ChunkConsumer    string   `json:"chunk_consumer"` // shared consumer name
+	ChunkCount       int      `json:"chunk_count,omitempty"`
+	Config           string   `json:"config,omitempty"`        // base64 scan configuration
+	ReportConfig     string   `json:"report_config,omitempty"` // base64 nuclei reporting (-rc) configuration
+	HistoryID        int64    `json:"history_id,omitempty"`
+	Steps            []string `json:"steps,omitempty"` // enumeration steps
+	EnumerationPorts string   `json:"enumeration_ports,omitempty"`
 }
 
 // ChunkMessage is a single unit of work decoded from the group stream.

--- a/pkg/types/exec_type.go
+++ b/pkg/types/exec_type.go
@@ -68,6 +68,7 @@ type Options struct {
 	HistoryID    int64
 
 	// Enumeration
-	EnumerationID string
-	Steps         []string
+	EnumerationID    string
+	Steps            []string
+	EnumerationPorts string
 }


### PR DESCRIPTION
Closes #154.

## Summary
- Adds `EnumerationPorts` field on `natsrpc.WorkMessage` and `types.Options`.
- Threads it through `Runner.executeEnumeration` -> `pkg.Run` -> `runtools.RunNaabu` so callers can override the port set per enumeration.
- Falls back to `top-100` when the field is empty (default behavior unchanged).

## Proof of work
Agent log from a run with `enumeration_ports: "1-65535"` in the work message — value reaches `executeEnumeration` end-to-end:
```
time=2026-05-19T23:59:25.928+05:30 level=INFO msg="Starting enumeration for enumID=d86ao07hr5ec73eseu90, metaID=3DxEYA5EKYvsbOnbP9Y0hw0pI3q, steps=8, assets=10, ports=1-65535"
```

## Test plan
- [x] Builds clean (`go build ./...`)
- [x] `WorkMessage` with explicit `enumeration_ports` reaches naabu (see log above)
- [ ] `WorkMessage` without the field falls back to top-100
