### PR TITLE
release v0.2.0 prep: multi-arch ghcr image, agent-network docs, CI hardening

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,9 @@ on:
       - '**.mod'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint Test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,9 +40,7 @@ jobs:
       - name: Test
         run: go test ./...
         working-directory: .
-        env:
-          PDCP_API_KEY: "${{ secrets.PDCP_API_KEY }}"
-          
+
       - name: Race Condition Tests
         run: go build -race .
         working-directory: cmd/pd-agent/

--- a/.github/workflows/ghcr-push.yml
+++ b/.github/workflows/ghcr-push.yml
@@ -7,12 +7,16 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Get Github tag
         id: meta
@@ -20,23 +24,24 @@ jobs:
           curl --silent "https://api.github.com/repos/projectdiscovery/pd-agent/releases/latest" | jq -r .tag_name | xargs -I {} echo TAG={} >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2 
+      - name: Login to GHCR
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             VERSION=${{ steps.meta.outputs.TAG }}
-          tags: projectdiscovery/pd-agent:latest,projectdiscovery/pd-agent:${{ steps.meta.outputs.TAG }}
+          tags: ghcr.io/projectdiscovery/pd-agent:latest,ghcr.io/projectdiscovery/pd-agent:${{ steps.meta.outputs.TAG }}

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -8,6 +8,9 @@ on:
       - '**.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release-test-mac:
     runs-on: macos-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM --platform=linux/amd64 golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 RUN apt-get update && apt-get install -y git
 
 ENV CGO_ENABLED=0
 
 ARG VERSION=dev
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /build
 COPY go.mod go.sum ./
@@ -15,41 +17,42 @@ COPY . .
 # into the binary via pkg/runtools, so this is the only artifact we need to
 # ship. Mzack9999/gopacket dlopens libpcap at runtime via purego, so no cgo
 # or libpcap headers are needed at build time; features that need libpcap
-# warn-and-skip at runtime if the lib is missing.
-RUN GOOS=linux go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" -o /go/bin/pd-agent ./cmd/pd-agent/main.go
+# warn-and-skip at runtime if the lib is missing. The builder runs on the
+# native BUILDPLATFORM and cross-compiles to TARGETARCH, so multi-arch images
+# build without QEMU-emulating the Go toolchain.
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w -X main.Version=${VERSION}" -o /go/bin/pd-agent ./cmd/pd-agent
 
-FROM --platform=linux/amd64 ubuntu:latest
-# Runtime dependencies: Chrome for nuclei/httpx headless screenshots, plus
+FROM debian:bookworm-slim
+# Runtime dependencies: chromium for nuclei/httpx headless screenshots. Debian
+# ships chromium for both amd64 and arm64 (Google Chrome is amd64-only), so the
+# image is genuinely multi-arch. fonts-liberation gives headless renders a base
+# font set; procps provides pgrep for the example k8s liveness/readiness probes;
 # ca-certificates for outbound TLS. naabu does service-version detection
 # natively (nmap-service-probes parsed in-process), so no nmap binary is
-# required. libpcap is intentionally not installed: naabu's syn-scan warns
-# and skips when it's missing. Users who want libpcap-backed features can
-# extend this image with `apt install libpcap0.8`.
-RUN apt update && apt install -y \
+# required. libpcap is intentionally not installed: naabu's syn-scan warns and
+# skips when it's missing. Extend with `apt install libpcap0.8` if you need it.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    wget \
-    gnupg \
-    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-    && apt update \
-    && apt install -y google-chrome-stable \
-    && apt clean \
+    chromium \
+    fonts-liberation \
+    procps \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CHROME_BIN=/usr/bin/google-chrome-stable
+ENV CHROME_BIN=/usr/bin/chromium
 ENV CHROME_PATH=/usr/bin/
 ENV CHROME_NO_SANDBOX=true
 
 COPY --from=builder /go/bin/pd-agent /usr/local/bin/pd-agent
 
-# Writable output directory for the ubuntu user (UID 1000)
-RUN mkdir -p /home/ubuntu/output && \
-    chown -R ubuntu:ubuntu /home/ubuntu
+# Non-root user (UID 1000 matches the example k8s securityContext). debian-slim
+# has no default user, so create one with a writable home for scan output.
+RUN useradd --create-home --uid 1000 --shell /usr/sbin/nologin pd-agent \
+    && mkdir -p /home/pd-agent/output \
+    && chown -R pd-agent:pd-agent /home/pd-agent
 
-ENV PDCP_API_KEY=""
-ENV PDCP_TEAM_ID=""
-
-USER ubuntu
-WORKDIR /home/ubuntu
+USER pd-agent
+WORKDIR /home/pd-agent
 
 ENTRYPOINT ["pd-agent"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Nuclei, httpx, naabu, dnsx, and tlsx are all built into the agent — there's no
      --network host --cap-add NET_RAW --cap-add NET_ADMIN \
      -e PDCP_API_KEY=your-api-key \
      -e PDCP_TEAM_ID=your-team-id \
-     projectdiscovery/pd-agent:latest \
+     ghcr.io/projectdiscovery/pd-agent:latest \
      -agent-network prod-vpc
    ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PDCP_AGENT_NAME` | hostname | Display name in the cloud UI. |
-| `PDCP_AGENT_NETWORK` | `default` | Network name the agent lives in. Scans from the cloud are routed to agents by network. |
+| `PDCP_AGENT_NETWORK` | **required** | Network name the agent lives in. Scans from the cloud are routed to agents by network, so every agent must set this. |
 | `AGENT_NETWORK` | — | Legacy alias for `PDCP_AGENT_NETWORK`. `PDCP_AGENT_NETWORK` wins if both are set. |
 | `PDCP_AGENT_OUTPUT` | — (temp dir) | Folder where the agent stashes per-chunk scan output before uploading. Each chunk gets its own subdirectory: `<PDCP_AGENT_OUTPUT>/<chunk-id>/`. Files are deleted after upload unless `PDCP_KEEP_OUTPUT_FILES=true`. If unset, the embedded scanners write to the OS temp directory. |
 
@@ -83,7 +83,7 @@ Every flag has an equivalent env var. Use whichever fits your deployment style �
 | `-verbose` | | `PDCP_VERBOSE` | Verbose logging. |
 | `-keep-output-files` | | `PDCP_KEEP_OUTPUT_FILES` | Keep output files after processing. |
 | `-agent-output` | | `PDCP_AGENT_OUTPUT` | Output folder for per-chunk scan files. |
-| `-agent-network` | `-an` | `PDCP_AGENT_NETWORK` | Network the agent belongs to. Scans are routed by this name. |
+| `-agent-network` | `-an` | `PDCP_AGENT_NETWORK` | **Required.** Network the agent belongs to. Scans are routed by this name. |
 | `-agent-name` | | `PDCP_AGENT_NAME` | Display name. |
 | `-agent-id` | | — | Pin the agent ID (auto-generated and persisted across self-updates if empty). |
 | `-chunk-parallelism` | `-c` | `PDCP_CHUNK_PARALLELISM` | Chunks per scan in parallel. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ docker run -d --name pd-agent \
   --network host --cap-add NET_RAW --cap-add NET_ADMIN \
   -e PDCP_API_KEY=your-api-key \
   -e PDCP_TEAM_ID=your-team-id \
-  projectdiscovery/pd-agent:latest \
+  ghcr.io/projectdiscovery/pd-agent:latest \
   -agent-network prod-vpc
 ```
 
@@ -32,7 +32,7 @@ docker run -d --name pd-agent \
 - `NET_RAW` / `NET_ADMIN` enable `naabu` SYN scanning. Drop them if you only need full-connect scans.
 - Image ships with Chrome (for `nuclei` / `httpx` headless screenshots) and trusts the system CA bundle.
 
-Image: <https://hub.docker.com/r/projectdiscovery/pd-agent>
+Image: <https://github.com/projectdiscovery/pd-agent/pkgs/container/pd-agent>
 
 ---
 
@@ -55,7 +55,7 @@ kubectl -n pd-agent logs -l app=pd-agent -f
 
 Before applying, open the manifest and adjust:
 
-- `args:` — set `-agent-network` to the name you want to route scans to (e.g. the cluster identifier).
+- `args:` — set the required `-agent-network` to the name you want to route scans to (e.g. the cluster identifier).
 - `replicas:` — start with 1, scale based on [`docs/scaling.md`](scaling.md).
 - `resources:` — defaults are fine for ≤100 hosts; large scans benefit from more memory.
 
@@ -82,7 +82,7 @@ sudo systemctl enable --now pd-agent
 sudo journalctl -u pd-agent -f
 ```
 
-Unit file: [`examples/pd-agent.service`](../examples/pd-agent.service). Replace the placeholder env vars before enabling.
+Unit file: [`examples/pd-agent.service`](../examples/pd-agent.service). Customize the placeholder vars for your setup before enabling: `PDCP_API_KEY`, `PDCP_TEAM_ID`, and `PDCP_AGENT_NETWORK` (required; the network scans are routed to).
 
 ---
 
@@ -106,7 +106,7 @@ launchctl load ~/Library/LaunchAgents/com.projectdiscovery.pd-agent.plist
 tail -f ~/.pd-agent/logs/stdout.log
 ```
 
-Plist: [`examples/com.projectdiscovery.pd-agent.plist`](../examples/com.projectdiscovery.pd-agent.plist).
+Plist: [`examples/com.projectdiscovery.pd-agent.plist`](../examples/com.projectdiscovery.pd-agent.plist). Customize the placeholders for your setup: the `PDCP_*` credentials and the required `-agent-network` value (the network scans are routed to).
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,8 +61,7 @@ The deployment manifest includes everything needed: namespace, service account, 
 
 Edit `pd-agent-deployment.yaml` to update:
 - **Namespace**: Change `pd-agent` to your desired namespace (update in all resources)
-- **Agent tags** (line 72): Change `production` to your desired tag
-- **Agent networks** (line 74): Change `kube-prod-cluster` to your cluster identifier
+- **Agent network** (line 72, required): Change `kube-prod-cluster` to the network name you want to route scans to
 - **Replicas**: Change `1` to your desired number of replicas
 
 **2. Create secret:**

--- a/examples/com.projectdiscovery.pd-agent.plist
+++ b/examples/com.projectdiscovery.pd-agent.plist
@@ -10,10 +10,12 @@
         <string>-agent-output</string>
         <string>/Users/YOUR_USERNAME/.pd-agent/output</string>
         <string>-verbose</string>
-        <string>-agent-tags</string>
+        <!-- Required: network name scans are routed to -->
+        <string>-agent-network</string>
         <string>production</string>
     </array>
     <key>EnvironmentVariables</key>
+    <!-- Customize these for your setup -->
     <dict>
         <key>PDCP_API_KEY</key>
         <string>your-api-key</string>

--- a/examples/pd-agent-deployment.yaml
+++ b/examples/pd-agent-deployment.yaml
@@ -62,13 +62,14 @@ spec:
         fsGroup: 1000
       containers:
       - name: pd-agent
-        image: projectdiscovery/pd-agent:latest
+        image: ghcr.io/projectdiscovery/pd-agent:latest
         securityContext:
           capabilities:
             add: ["NET_RAW", "NET_ADMIN"]
         imagePullPolicy: Always
         args:
-          - -agent-networks
+          # Required: network name scans are routed to
+          - -agent-network
           - kube-prod-cluster
         env:
           # Sensitive data from Secret

--- a/examples/pd-agent.service
+++ b/examples/pd-agent.service
@@ -6,9 +6,11 @@ After=network.target
 Type=simple
 User=pd-agent
 Group=pd-agent
+# Customize these for your setup:
 Environment="PDCP_API_KEY=your-api-key"
 Environment="PDCP_TEAM_ID=your-team-id"
-Environment="PDCP_AGENT_TAGS=production"
+# Required: network name scans are routed to
+Environment="PDCP_AGENT_NETWORK=production"
 ExecStart=/usr/local/bin/pd-agent -agent-output /var/lib/pd-agent/output -verbose
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Release-prep for v0.2.0, split into focused commits.

### Docs & examples
- Rename stale `-agent-tags` / `-agent-networks` / `PDCP_AGENT_TAGS` to `-agent-network` (these no longer exist after the rename).
- Mark `agent-network` as **required**, add placeholder hints for vars to customize.
- Point image pulls at `ghcr.io/projectdiscovery/pd-agent`.

### Docker (arch)
- Build the whole `./cmd/pd-agent` package instead of `main.go` alone — fixes the build that broke once the package gained sibling files (`prometheus.go`, `loghandler.go`).
- Multi-arch **amd64 + arm64**: cross-compile via `TARGETARCH` on `$BUILDPLATFORM`, swap amd64-only `google-chrome` for Debian `chromium`.

### CI
- Publish the release image to **ghcr** instead of Docker Hub (`GITHUB_TOKEN`, `packages: write`).
- **Security:** drop the unused `PDCP_API_KEY` secret from the PR test job (exfil landmine if ever switched to `pull_request_target`).
- **Security:** set least-privilege `contents: read` on PR-triggered workflows.

### ⚠️ Before merge / release
- The **arm64 chromium image is unvalidated** — needs a local `buildx --platform linux/arm64` build + headless scan smoke test.
- 32-bit `linux/arm` dropped (Debian has no `chromium` for armhf).

### Not included (your call)
- dependabot `target: all` + SHA-pinning the PAT action.
- Re-enabling CodeQL (currently `.old`).