### PR TITLE
docs(install): note internal-target safety before the first scan

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -4,6 +4,8 @@ Install `pd-agent` on a machine inside the network you want to scan. Once it's r
 
 **Before you start:** grab your `PDCP_API_KEY` and `PDCP_TEAM_ID` from <https://cloud.projectdiscovery.io>.
 
+**Before you scan:** internal ranges usually contain printers, OT controllers, and VoIP phones. Some Nuclei templates reach these over raw print protocols or SNMP and can print pages or hang the device. Read [safety considerations](https://docs.projectdiscovery.io/cloud/scanning/internal-scan#safety-considerations) before the first scan.
+
 Pick the install path that matches where the agent will live:
 
 | Method | Best for |


### PR DESCRIPTION
The install guide takes an operator from credentials to a first scan without mentioning what tends to be sitting on an internal range. Printers, OT controllers, and VoIP phones are common there, and some Nuclei templates reach them over raw print protocols or SNMP and can print pages or hang the device.

Adds two lines under **Before you start**, pointing at the safety considerations section on the platform docs rather than restating it here.

That section is added in projectdiscovery/docs#237.