### PR TITLE
Shubh/misc tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ output/*
 
 local/
 .claude/
+
+# local run artifacts
+scan-auto*.log
+.agents/

--- a/cmd/pd-agent/heartbeat_test.go
+++ b/cmd/pd-agent/heartbeat_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestHeartbeatQuery(t *testing.T) {
+	options := &Options{
+		AgentId:      "d0abcd1234567890abcd",
+		AgentName:    "shubham-mac",
+		AgentNetwork: "shubham-mac",
+	}
+
+	got := heartbeatQuery(options, "v1.2.3", []string{"192.168.0.0/24", "10.0.0.0/8"})
+
+	want := map[string]string{
+		"os":              runtime.GOOS,
+		"arch":            runtime.GOARCH,
+		"id":              "d0abcd1234567890abcd",
+		"name":            "shubham-mac",
+		"agent_network":   "shubham-mac",
+		"version":         "v1.2.3",
+		"network_subnets": "192.168.0.0/24,10.0.0.0/8",
+	}
+	for key, wantValue := range want {
+		if gotValue := got.Get(key); gotValue != wantValue {
+			t.Errorf("%s = %q, want %q", key, gotValue, wantValue)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("query has %d params, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// The platform reads the running build off the heartbeat, so the parameter has
+// to survive every code path, including a dev binary with no ldflags stamp.
+func TestHeartbeatQueryAlwaysCarriesVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "release build", version: "v1.4.0"},
+		{name: "unstamped dev build", version: "dev"},
+		{name: "empty", version: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := heartbeatQuery(&Options{}, tt.version, nil)
+			if _, present := got["version"]; !present {
+				t.Fatalf("version parameter absent for %q", tt.version)
+			}
+			if got.Get("version") != tt.version {
+				t.Errorf("version = %q, want %q", got.Get("version"), tt.version)
+			}
+		})
+	}
+}
+
+func TestHeartbeatQueryOmitsEmptySubnets(t *testing.T) {
+	for _, subnets := range [][]string{nil, {}} {
+		got := heartbeatQuery(&Options{}, "v1.0.0", subnets)
+		if _, present := got["network_subnets"]; present {
+			t.Errorf("network_subnets present for %v, want it omitted", subnets)
+		}
+	}
+}
+
+// A name or network with a space or slash must not corrupt the query.
+func TestHeartbeatQueryEncodesValues(t *testing.T) {
+	options := &Options{AgentId: "id/1", AgentName: "a b", AgentNetwork: "n&m"}
+	encoded := heartbeatQuery(options, "v1.0.0", nil).Encode()
+
+	parsed, err := url.ParseQuery(encoded)
+	if err != nil {
+		t.Fatalf("ParseQuery(%q): %v", encoded, err)
+	}
+	if parsed.Get("name") != "a b" || parsed.Get("agent_network") != "n&m" || parsed.Get("id") != "id/1" {
+		t.Errorf("round-trip lost values: %v", parsed)
+	}
+	if strings.Contains(encoded, " ") {
+		t.Errorf("encoded query contains a raw space: %q", encoded)
+	}
+}

--- a/cmd/pd-agent/main.go
+++ b/cmd/pd-agent/main.go
@@ -1815,6 +1815,23 @@ func (r *Runner) In(ctx context.Context) error {
 
 var isRegistered bool
 
+// heartbeatQuery builds the /in query string. Every heartbeat carries the
+// running version so the platform can record which build an agent is on
+// without broadcasting a health-check RPC to ask.
+func heartbeatQuery(options *Options, version string, networkSubnets []string) url.Values {
+	q := url.Values{}
+	q.Set("os", runtime.GOOS)
+	q.Set("arch", runtime.GOARCH)
+	q.Set("id", options.AgentId)
+	q.Set("name", options.AgentName)
+	q.Set("agent_network", options.AgentNetwork)
+	q.Set("version", version)
+	if len(networkSubnets) > 0 {
+		q.Set("network_subnets", strings.Join(networkSubnets, ","))
+	}
+	return q
+}
+
 // inFunctionTickCallback runs one register/heartbeat cycle: GET /v1/agents/{id}
 // to sync server-authoritative state, then POST /v1/agents/in to refresh the
 // 7-minute Redis TTL and obtain NATS credentials.
@@ -1888,22 +1905,14 @@ func (r *Runner) inFunctionTickCallback(ctx context.Context) error {
 		return err
 	}
 
-	q := req.URL.Query()
-	q.Add("os", runtime.GOOS)
-	q.Add("arch", runtime.GOARCH)
-	q.Add("id", r.options.AgentId)
-	q.Add("name", r.options.AgentName)
-	q.Add("agent_network", r.options.AgentNetwork)
-
 	networkSubnets := r.getAutoDiscoveredTargets()
 	if len(networkSubnets) > 0 {
 		r.logHelper("DEBUG", fmt.Sprintf("Discovered network subnets: %v", networkSubnets))
-		q.Add("network_subnets", strings.Join(networkSubnets, ","))
 	} else {
 		r.logHelper("INFO", "No network subnets discovered")
 	}
 
-	req.URL.RawQuery = q.Encode()
+	req.URL.RawQuery = heartbeatQuery(r.options, Version, networkSubnets).Encode()
 
 	inResp := r.makeRequest(inCtx, http.MethodPost, req.URL.String(), nil, nil)
 	if inResp.Error != nil {
@@ -1948,7 +1957,7 @@ func (r *Runner) inFunctionTickCallback(ctx context.Context) error {
 	}
 
 	if !isRegistered {
-		r.logHelper("INFO", "agent registered successfully")
+		r.logHelper("INFO", fmt.Sprintf("agent registered successfully (version=%s)", Version))
 		isRegistered = true
 	}
 

--- a/cmd/pd-agent/main.go
+++ b/cmd/pd-agent/main.go
@@ -69,33 +69,38 @@ func ensureNucleiTemplates() {
 	}
 
 	if info, err := os.Stat(templateDir); err == nil && info.IsDir() {
-		slog.Info("Nuclei templates directory exists, checking for updates...", "path", templateDir)
+		slog.Info("Nuclei templates directory exists, checking the newest release...", "path", templateDir)
 	} else {
 		slog.Info("Nuclei templates not found, downloading...", "path", templateDir)
 	}
 
-	if err := runtools.UpdateNucleiTemplates(); err != nil {
-		slog.Error("Failed to update nuclei templates", "error", err)
+	from, to, err := runtools.EnsureLatestTemplates(context.Background())
+	if err != nil {
+		slog.Error("Failed to update nuclei templates", "error", err, "version", from)
 		os.Exit(1)
 	}
-	slog.Info("Nuclei templates are up to date", "path", templateDir)
+	if from == to {
+		slog.Info("Nuclei templates verified against the newest release", "path", templateDir, "version", to)
+	} else {
+		slog.Info("Nuclei templates updated", "path", templateDir, "from", from, "to", to)
+	}
 }
-
-// templateUpdateMu serializes template refreshes so concurrent scans
-// (ScanParallelism > 1) never rewrite the shared template dir at once.
-var templateUpdateMu sync.Mutex
 
 // refreshTemplatesForScan pulls newer nuclei templates before a scan's chunks
 // run, so a long-lived agent picks up releases without a restart. Non-fatal:
 // boot already guaranteed a usable set, so a transient update failure logs and
 // proceeds on the existing templates rather than dropping the scan.
-func refreshTemplatesForScan(scanID string) {
-	templateUpdateMu.Lock()
-	defer templateUpdateMu.Unlock()
-
-	if err := runtools.UpdateNucleiTemplates(); err != nil {
+func refreshTemplatesForScan(ctx context.Context, scanID string) {
+	from, to, err := runtools.EnsureLatestTemplates(ctx)
+	if err != nil {
+		// An unreachable release API must not stall scanning; per-chunk
+		// verification still guarantees the templates this scan needs.
 		slog.Warn("Failed to refresh nuclei templates before scan, using existing set",
-			"scan_id", scanID, "error", err)
+			"scan_id", scanID, "version", from, "error", err)
+		return
+	}
+	if from != to {
+		slog.Info("Nuclei templates updated before scan", "scan_id", scanID, "from", from, "to", to)
 	}
 }
 
@@ -1245,7 +1250,7 @@ func (r *Runner) processJetStreamScan(ctx context.Context, work *natsrpc.WorkMes
 		_ = r.agentDB.InsertTask(context.Background(), &agentdb.Task{Type: "scan", TaskID: work.ScanID})
 	}
 
-	refreshTemplatesForScan(work.ScanID)
+	refreshTemplatesForScan(ctx, work.ScanID)
 
 	err := func() error {
 		creds := r.GetNATSCredentials()

--- a/cmd/pd-agent/main.go
+++ b/cmd/pd-agent/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/projectdiscovery/pd-agent/pkg/runtools"
 	"github.com/projectdiscovery/pd-agent/pkg/selfupdate"
 	"github.com/projectdiscovery/pd-agent/pkg/types"
+	"github.com/projectdiscovery/pd-agent/pkg/validate"
 	fileutil "github.com/projectdiscovery/utils/file"
 	"github.com/rs/xid"
 	"github.com/tidwall/gjson"
@@ -341,9 +342,11 @@ func NewRunner(options *Options) (*Runner, error) {
 	}
 
 	if r.options.AgentName == "" {
-		if hostname, err := os.Hostname(); err == nil && hostname != "" {
-			r.options.AgentName = hostname
-		} else {
+		// Hostnames routinely break the name rules (".local" suffix, spaces): coerce, never reject.
+		if hostname, err := os.Hostname(); err == nil {
+			r.options.AgentName = validate.SanitizeName(hostname)
+		}
+		if r.options.AgentName == "" {
 			r.options.AgentName = r.options.AgentId
 		}
 	}
@@ -1827,12 +1830,21 @@ func (r *Runner) inFunctionTickCallback(ctx context.Context) error {
 		} else {
 			agentInfo := response.Agent
 			if agentInfo.AgentNetwork != "" && agentInfo.AgentNetwork != r.options.AgentNetwork {
-				r.logHelper("INFO", fmt.Sprintf("Using agent_network from %s server: %s (was: %s)", envconfig.APIServer(), agentInfo.AgentNetwork, r.options.AgentNetwork))
-				r.options.AgentNetwork = agentInfo.AgentNetwork
+				// Keep the local value rather than kill a running agent over a bad response.
+				if serverNetwork, err := validate.Name("agent_network", agentInfo.AgentNetwork); err != nil {
+					r.logHelper("WARNING", fmt.Sprintf("ignoring agent_network from %s server: %v", envconfig.APIServer(), err))
+				} else {
+					r.logHelper("INFO", fmt.Sprintf("Using agent_network from %s server: %s (was: %s)", envconfig.APIServer(), serverNetwork, r.options.AgentNetwork))
+					r.options.AgentNetwork = serverNetwork
+				}
 			}
 			if agentInfo.Name != "" && agentInfo.Name != r.options.AgentName {
-				r.logHelper("INFO", fmt.Sprintf("Using agent name from %s server: %s (was: %s)", envconfig.APIServer(), agentInfo.Name, r.options.AgentName))
-				r.options.AgentName = agentInfo.Name
+				if serverName, err := validate.Name("name", agentInfo.Name); err != nil {
+					r.logHelper("WARNING", fmt.Sprintf("ignoring agent name from %s server: %v", envconfig.APIServer(), err))
+				} else {
+					r.logHelper("INFO", fmt.Sprintf("Using agent name from %s server: %s (was: %s)", envconfig.APIServer(), serverName, r.options.AgentName))
+					r.options.AgentName = serverName
+				}
 			}
 			r.logHelper("DEBUG", fmt.Sprintf("Agent last updated at: %s", agentInfo.LastUpdate.Format(time.RFC3339)))
 		}
@@ -2357,6 +2369,22 @@ func parseOptions() *Options {
 
 	if options.AgentNetwork == "" {
 		options.AgentNetwork = "default"
+	}
+	agentNetwork, err := validate.Name("agent-network", options.AgentNetwork)
+	if err != nil {
+		slog.Error("invalid agent network", "error", err)
+		os.Exit(1)
+	}
+	options.AgentNetwork = agentNetwork
+
+	// An empty name is derived from the hostname later; only explicit input is checked here.
+	if options.AgentName != "" {
+		agentName, err := validate.Name("agent-name", options.AgentName)
+		if err != nil {
+			slog.Error("invalid agent name", "error", err)
+			os.Exit(1)
+		}
+		options.AgentName = agentName
 	}
 
 	// 0 = auto-detect for chunks.

--- a/cmd/pd-agent/main.go
+++ b/cmd/pd-agent/main.go
@@ -57,10 +57,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// ensureNucleiTemplates installs or updates nuclei templates, exiting the
-// process on failure. Without a complete template set the agent would emit
-// "file not found" errors mid-scan for every cloud-sent path missing locally,
-// so a failed install/update is fatal rather than a silent degrade.
+// ensureNucleiTemplates installs or updates nuclei templates. Without a set the
+// agent would emit "file not found" errors mid-scan for every cloud-sent path
+// missing locally, so templateBootFatal decides what is worth aborting for.
 func ensureNucleiTemplates() {
 	templateDir := pkg.GetNucleiDefaultTemplateDir()
 	if templateDir == "" {
@@ -76,7 +75,12 @@ func ensureNucleiTemplates() {
 
 	from, to, err := runtools.EnsureLatestTemplates(context.Background())
 	if err != nil {
-		slog.Error("Failed to update nuclei templates", "error", err, "version", from)
+		if !templateBootFatal(err, from) {
+			slog.Warn("Could not confirm the newest nuclei-templates release, continuing on the installed set",
+				"path", templateDir, "version", from, "error", err)
+			return
+		}
+		slog.Error("Failed to install nuclei templates", "error", err, "version", from)
 		os.Exit(1)
 	}
 	if from == to {
@@ -84,6 +88,17 @@ func ensureNucleiTemplates() {
 	} else {
 		slog.Info("Nuclei templates updated", "path", templateDir, "from", from, "to", to)
 	}
+}
+
+// templateBootFatal reports whether a boot-time template failure should stop
+// the agent. A set that could not be confirmed as newest is still usable, so
+// an unreachable release API must not ground a fleet; having no templates at
+// all is fatal. The lookup and the download carry their own 30s timeouts.
+func templateBootFatal(err error, installed string) bool {
+	if err == nil {
+		return false
+	}
+	return !errors.Is(err, runtools.ErrFreshnessUnknown) || installed == ""
 }
 
 // refreshTemplatesForScan pulls newer nuclei templates before a scan's chunks

--- a/cmd/pd-agent/templates_test.go
+++ b/cmd/pd-agent/templates_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/projectdiscovery/pd-agent/pkg/runtools"
+)
+
+// This decides whether an unreachable GitHub grounds a whole fleet, so every
+// combination is pinned.
+func TestTemplateBootFatal(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		installed string
+		want      bool
+	}{
+		{
+			name:      "no error",
+			err:       nil,
+			installed: "v10.4.8",
+			want:      false,
+		},
+		{
+			name:      "freshness unknown with templates on disk",
+			err:       fmt.Errorf("%w: api down", runtools.ErrFreshnessUnknown),
+			installed: "v10.4.5",
+			want:      false,
+		},
+		{
+			name:      "rate limited with templates on disk",
+			err:       fmt.Errorf("%w: %w", runtools.ErrFreshnessUnknown, runtools.ErrGitHubRateLimited),
+			installed: "v10.4.5",
+			want:      false,
+		},
+		{
+			name:      "freshness unknown with no templates",
+			err:       fmt.Errorf("%w: api down", runtools.ErrFreshnessUnknown),
+			installed: "",
+			want:      true,
+		},
+		{
+			name:      "install failed",
+			err:       errors.New("install templates: disk full"),
+			installed: "",
+			want:      true,
+		},
+		{
+			name:      "install failed with a stale set on disk",
+			err:       errors.New("fresh install templates: disk full"),
+			installed: "v10.4.5",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := templateBootFatal(tt.err, tt.installed); got != tt.want {
+				t.Errorf("templateBootFatal(%v, %q) = %v, want %v", tt.err, tt.installed, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,7 @@ The agent keeps a small rolling log + metrics buffer at `~/.pd-agent/pd-agent-<a
 | `PDCP_VERBOSE` | `false` | Verbose logging. Same as `-verbose`. |
 | `PDCP_KEEP_OUTPUT_FILES` | `false` | Keep per-chunk output files after upload (debugging). Same as `-keep-output-files`. |
 | `PDCP_ENABLE_SCAN_LOG_UPLOAD` | `false` | Upload the gzipped per-scan log to the platform. Off by default — leave off unless the platform has scan-log storage provisioned for your team. |
+| `PDCP_ALLOW_MISSING_TEMPLATES` | `false` | Scan even when templates the platform requested cannot be resolved. Off by default: an incomplete set reports a clean scan for checks that never ran. |
 | `LOCAL_K8S` | `false` | Use `KUBECONFIG` instead of the in-cluster service account when discovering Kubernetes subnets. Strict `true` match. |
 
 ### Networking & API
@@ -53,6 +54,7 @@ The agent keeps a small rolling log + metrics buffer at `~/.pd-agent/pd-agent-<a
 | --- | --- | --- |
 | `PDCP_API_SERVER` | `https://api.projectdiscovery.io` | Override only for dev environments. |
 | `PROXY_URL` | — | Outbound HTTP(S) proxy for agent → platform traffic. |
+| `GITHUB_TOKEN` | — | Raises the GitHub API limit from 60/hr per IP to 5000/hr for nuclei-template release lookups and downloads. Worth setting on any fleet sharing an egress IP. |
 
 ### Observability
 

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -32,6 +32,14 @@ func APIServer() string { return envutil.GetEnvOrDefault(KeyAPIServer, DefaultAP
 // UpdateURL overrides the self-update download URL; empty resolves via GitHub releases.
 func UpdateURL() string { return envutil.GetEnvOrDefault(KeyUpdateURL, "") }
 
+// KeyGitHubToken is read by projectdiscovery/utils/update for every
+// nuclei-templates download; the agent reuses it for the release lookup so a
+// fleet shares one 5000/hr budget instead of 60/hr per NAT egress IP.
+const KeyGitHubToken = "GITHUB_TOKEN"
+
+// GitHubToken returns GITHUB_TOKEN; empty means unauthenticated GitHub access.
+func GitHubToken() string { return envutil.GetEnvOrDefault(KeyGitHubToken, "") }
+
 // ---------- Agent identity & topology ----------
 
 const (
@@ -104,6 +112,7 @@ const (
 	KeyLocalK8s                = "LOCAL_K8S"
 	KeyDisableDiagnosticUpload = "PDCP_DISABLE_DIAGNOSTIC_UPLOAD"
 	KeyEnableScanLogUpload     = "PDCP_ENABLE_SCAN_LOG_UPLOAD"
+	KeyAllowMissingTemplates   = "PDCP_ALLOW_MISSING_TEMPLATES"
 )
 
 // Verbose returns true when PDCP_VERBOSE is truthy.
@@ -126,6 +135,13 @@ func DisableDiagnosticUpload() bool {
 // provisioned don't hammer the API with rejected uploads.
 func ScanLogUploadEnabled() bool {
 	return envutil.GetEnvOrDefault(KeyEnableScanLogUpload, false)
+}
+
+// AllowMissingTemplates lets a scan run when templates the platform requested
+// are absent even after a reinstall. Off by default: an incomplete set reports
+// a clean scan for checks that never ran.
+func AllowMissingTemplates() bool {
+	return envutil.GetEnvOrDefault(KeyAllowMissingTemplates, false)
 }
 
 // ---------- Observability ----------

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -296,14 +296,16 @@ func runNucleiScan(ctx context.Context, task *types.Task) (*types.TaskResult, []
 	// silently, reporting a clean scan that never ran those checks. The repair is
 	// queued for the next scan rather than run here.
 	if missing := runtools.VerifyTemplatesFor(opts.Templates); len(missing) > 0 {
-		runtools.RequestTemplateRepair(fmt.Sprintf("%d templates missing on scan %s", len(missing), task.Options.ScanID))
+		if runtools.AnyPublic(missing) {
+			runtools.RequestTemplateRepair(fmt.Sprintf("%d templates unresolved on scan %s", len(missing), task.Options.ScanID))
+		}
 
 		shown := missing
 		if len(shown) > 3 {
 			shown = shown[:3]
 		}
 		if !envconfig.AllowMissingTemplates() {
-			return nil, nil, fmt.Errorf("nuclei scan: %d of %d requested templates missing from %s (e.g. %v); a reinstall is queued for the next scan, or set %s=true to scan with an incomplete set",
+			return nil, nil, fmt.Errorf("nuclei scan: %d of %d requested templates could not be resolved under %s (e.g. %v); a reinstall is queued for the next scan, or set %s=true to scan with an incomplete set",
 				len(missing), len(opts.Templates), runtools.TemplateDir(), shown, envconfig.KeyAllowMissingTemplates)
 		}
 		slog.Error("nuclei scan: scanning with an incomplete template set",

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -292,6 +292,20 @@ func runNucleiScan(ctx context.Context, task *types.Task) (*types.TaskResult, []
 		"config_bytes", len(opts.ConfigYAML),
 	)
 
+	// A template the platform scheduled but the agent lacks would be skipped
+	// silently, reporting a clean scan that never ran those checks.
+	if missing, err := runtools.EnsureTemplatesFor(ctx, opts.Templates); err != nil {
+		if !envconfig.AllowMissingTemplates() {
+			return nil, nil, fmt.Errorf("nuclei scan: %w (set %s=true to scan with an incomplete set)",
+				err, envconfig.KeyAllowMissingTemplates)
+		}
+		slog.Error("nuclei scan: scanning with an incomplete template set",
+			"scan_id", task.Options.ScanID,
+			"chunk_id", task.Id,
+			"missing_count", len(missing),
+			"error", err)
+	}
+
 	// Match upload is handled by the nuclei SDK via WithPDCPUpload.
 	if _, err := runtools.RunNuclei(ctx, opts); err != nil {
 		return nil, nil, fmt.Errorf("nuclei scan: %w", err)

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -1,27 +1,22 @@
 package pkg
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/base64"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	"log/slog"
 
 	"github.com/projectdiscovery/pd-agent/pkg/client"
 	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
 	"github.com/projectdiscovery/pd-agent/pkg/runtools"
+	"github.com/projectdiscovery/pd-agent/pkg/scanlog"
 	"github.com/projectdiscovery/pd-agent/pkg/types"
 	fileutil "github.com/projectdiscovery/utils/file"
 	sliceutil "github.com/projectdiscovery/utils/slice"
@@ -302,11 +297,16 @@ func runNucleiScan(ctx context.Context, task *types.Task) (*types.TaskResult, []
 		return nil, nil, fmt.Errorf("nuclei scan: %w", err)
 	}
 
-	// Raw scan-log upload (full JSONL, matched + unmatched). Opt-in via
-	// PDCP_ENABLE_SCAN_LOG_UPLOAD; default off so agents without storage
-	// provisioned don't hammer the API with rejected uploads.
-	if envconfig.ScanLogUploadEnabled() && task.Options.ScanID != "" && task.Options.HistoryID != 0 {
-		if err := uploadNucleiOutputViaSignedURL(ctx, task, outputFile); err != nil {
+	// Raw scan-log upload (full JSONL, matched + unmatched), best-effort: a
+	// storage failure must not fail the chunk.
+	if dests := scanlog.Destinations(); len(dests) > 0 && task.Options.ScanID != "" && task.Options.HistoryID != 0 {
+		meta := scanlog.Meta{
+			TeamID:    task.Options.TeamID,
+			ScanID:    task.Options.ScanID,
+			ChunkID:   task.Id,
+			HistoryID: task.Options.HistoryID,
+		}
+		if err := scanlog.Upload(ctx, dests, meta, outputFile); err != nil {
 			slog.Warn("nuclei scan: scan-log upload failed",
 				"scan_id", task.Options.ScanID,
 				"history_id", task.Options.HistoryID,
@@ -318,174 +318,6 @@ func runNucleiScan(ctx context.Context, task *types.Task) (*types.TaskResult, []
 	// Empty TaskResult: embedded path doesn't capture stdout/stderr, so
 	// ExtractUnresponsiveHosts has no input until we hook nuclei's logger.
 	return &types.TaskResult{}, []string{outputFile}, nil
-}
-
-// signedUploadResponse mirrors /v1/scans/{scan_id}/scan_log/upload-url.
-// Headers are authoritative: set them verbatim on the PUT and add nothing
-// else, since the SigV4 signature covers headers.
-type signedUploadResponse struct {
-	UploadURL  string            `json:"upload_url"`
-	Method     string            `json:"method"`
-	Headers    map[string]string `json:"headers"`
-	MaxBytes   int64             `json:"max_bytes"`
-	ObjectPath string            `json:"object_path"`
-	ExpiresAt  time.Time         `json:"expires_at"`
-}
-
-// uploadNucleiOutputViaSignedURL ships the per-chunk output via:
-//  1. POST /v1/scans/{scan_id}/scan_log/upload-url?history_id=N with {"filename": ...}
-//  2. PUT gzipped bytes to the signed URL with the response Headers verbatim.
-//
-// Gzipped as an opaque .gz blob (no Content-Encoding) so the SigV4 signed
-// headers never need to cover Content-Encoding; server gunzips on read.
-func uploadNucleiOutputViaSignedURL(ctx context.Context, task *types.Task, outputFile string) error {
-	info, err := os.Stat(outputFile)
-	if err != nil {
-		return fmt.Errorf("stat output: %w", err)
-	}
-	if info.Size() == 0 {
-		slog.Debug("nuclei scan: output file empty, skipping scan-log upload",
-			"scan_id", task.Options.ScanID, "chunk_id", task.Id)
-		return nil
-	}
-
-	// Gzip into a sibling temp so we can stat for ContentLength. Unique name
-	// keeps a redelivered chunk from clobbering a still-PUTting goroutine.
-	gzFile, err := os.CreateTemp(filepath.Dir(outputFile), filepath.Base(outputFile)+"-*.gz")
-	if err != nil {
-		return fmt.Errorf("create gz tempfile: %w", err)
-	}
-	gzPath := gzFile.Name()
-	_ = gzFile.Close()
-	defer func() { _ = os.Remove(gzPath) }()
-	gzSize, err := gzipFile(outputFile, gzPath)
-	if err != nil {
-		return fmt.Errorf("gzip output: %w", err)
-	}
-
-	slog.Debug("nuclei scan: gzipped scan-log",
-		"scan_id", task.Options.ScanID, "chunk_id", task.Id,
-		"raw_bytes", info.Size(), "gz_bytes", gzSize)
-
-	filename := task.Id + ".jsonl.gz"
-	httpClient, err := client.CreateAuthenticatedClient(task.Options.TeamID, envconfig.APIKey())
-	if err != nil {
-		return fmt.Errorf("auth client: %w", err)
-	}
-
-	reqBody, _ := json.Marshal(map[string]string{"filename": filename})
-	apiURL := fmt.Sprintf("%s/v1/scans/%s/scan_log/upload-url?history_id=%d",
-		envconfig.APIServer(), task.Options.ScanID, task.Options.HistoryID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
-	if err != nil {
-		return fmt.Errorf("build upload-url request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("get upload-url: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("upload-url status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var signed signedUploadResponse
-	if err := json.Unmarshal(respBody, &signed); err != nil {
-		return fmt.Errorf("decode upload-url response: %w", err)
-	}
-	if signed.UploadURL == "" || signed.Method == "" {
-		return fmt.Errorf("upload-url response missing url/method")
-	}
-	if signed.MaxBytes > 0 && gzSize > signed.MaxBytes {
-		return fmt.Errorf("gzipped output %d bytes exceeds signed-url max %d", gzSize, signed.MaxBytes)
-	}
-
-	f, err := os.Open(gzPath)
-	if err != nil {
-		return fmt.Errorf("open gz: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-
-	putReq, err := http.NewRequestWithContext(ctx, signed.Method, signed.UploadURL, f)
-	if err != nil {
-		return fmt.Errorf("build PUT: %s", stripSignedURL(err))
-	}
-	putReq.ContentLength = gzSize
-	for k, v := range signed.Headers {
-		putReq.Header.Set(k, v)
-	}
-
-	putResp, err := http.DefaultClient.Do(putReq)
-	if err != nil {
-		return fmt.Errorf("PUT: %s", stripSignedURL(err))
-	}
-	defer func() { _ = putResp.Body.Close() }()
-
-	if putResp.StatusCode != http.StatusOK && putResp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(putResp.Body)
-		return fmt.Errorf("PUT status %d: %s", putResp.StatusCode, string(body))
-	}
-	_, _ = io.Copy(io.Discard, putResp.Body)
-
-	slog.Info("nuclei scan: output file uploaded",
-		"scan_id", task.Options.ScanID,
-		"history_id", task.Options.HistoryID,
-		"chunk_id", task.Id,
-		"raw_bytes", info.Size(),
-		"gz_bytes", gzSize,
-		"object_path", signed.ObjectPath)
-	return nil
-}
-
-// stripSignedURL drops the URL from a *url.Error so SigV4/GCS HMAC query
-// signatures never reach the logs. Keeps operation and underlying cause.
-func stripSignedURL(err error) string {
-	var ue *url.Error
-	if errors.As(err, &ue) {
-		return fmt.Sprintf("%s: %s", ue.Op, ue.Err)
-	}
-	return err.Error()
-}
-
-// gzipFile streams src through gzip into dst at BestSpeed (nuclei JSONL
-// compresses ~10x even at level 1) and returns the dst size.
-func gzipFile(src, dst string) (int64, error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return 0, fmt.Errorf("open src: %w", err)
-	}
-	defer func() { _ = in.Close() }()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return 0, fmt.Errorf("create dst: %w", err)
-	}
-	gzw, err := gzip.NewWriterLevel(out, gzip.BestSpeed)
-	if err != nil {
-		_ = out.Close()
-		return 0, fmt.Errorf("gzip writer: %w", err)
-	}
-	if _, err := io.Copy(gzw, in); err != nil {
-		_ = gzw.Close()
-		_ = out.Close()
-		return 0, fmt.Errorf("gzip copy: %w", err)
-	}
-	if err := gzw.Close(); err != nil {
-		_ = out.Close()
-		return 0, fmt.Errorf("gzip close: %w", err)
-	}
-	if err := out.Close(); err != nil {
-		return 0, fmt.Errorf("close dst: %w", err)
-	}
-	st, err := os.Stat(dst)
-	if err != nil {
-		return 0, fmt.Errorf("stat dst: %w", err)
-	}
-	return st.Size(), nil
 }
 
 // splitIPsAndHostnames separates IPs from hostnames; strips port if present.

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -293,17 +293,24 @@ func runNucleiScan(ctx context.Context, task *types.Task) (*types.TaskResult, []
 	)
 
 	// A template the platform scheduled but the agent lacks would be skipped
-	// silently, reporting a clean scan that never ran those checks.
-	if missing, err := runtools.EnsureTemplatesFor(ctx, opts.Templates); err != nil {
+	// silently, reporting a clean scan that never ran those checks. The repair is
+	// queued for the next scan rather than run here.
+	if missing := runtools.VerifyTemplatesFor(opts.Templates); len(missing) > 0 {
+		runtools.RequestTemplateRepair(fmt.Sprintf("%d templates missing on scan %s", len(missing), task.Options.ScanID))
+
+		shown := missing
+		if len(shown) > 3 {
+			shown = shown[:3]
+		}
 		if !envconfig.AllowMissingTemplates() {
-			return nil, nil, fmt.Errorf("nuclei scan: %w (set %s=true to scan with an incomplete set)",
-				err, envconfig.KeyAllowMissingTemplates)
+			return nil, nil, fmt.Errorf("nuclei scan: %d of %d requested templates missing from %s (e.g. %v); a reinstall is queued for the next scan, or set %s=true to scan with an incomplete set",
+				len(missing), len(opts.Templates), runtools.TemplateDir(), shown, envconfig.KeyAllowMissingTemplates)
 		}
 		slog.Error("nuclei scan: scanning with an incomplete template set",
 			"scan_id", task.Options.ScanID,
 			"chunk_id", task.Id,
 			"missing_count", len(missing),
-			"error", err)
+			"sample", shown)
 	}
 
 	// Match upload is handled by the nuclei SDK via WithPDCPUpload.

--- a/pkg/execute_test.go
+++ b/pkg/execute_test.go
@@ -1,0 +1,453 @@
+package pkg
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/projectdiscovery/pd-agent/pkg/types"
+)
+
+const testScanLogLine = `{"template-id":"test","host":"example.com","matched-at":"example.com:443"}` + "\n"
+
+type recordedRequest struct {
+	method        string
+	path          string
+	rawQuery      string
+	header        http.Header
+	body          []byte
+	contentLength int64
+}
+
+// scanLogServer fakes the platform presign endpoint plus the object store the
+// signed URL points at, and records both requests for assertions.
+type scanLogServer struct {
+	mu       sync.Mutex
+	presign  []recordedRequest
+	put      []recordedRequest
+	srv      *httptest.Server
+	response func(putURL string) (int, any)
+	putCode  int
+	putBody  string
+}
+
+func newScanLogServer(t *testing.T) *scanLogServer {
+	t.Helper()
+
+	s := &scanLogServer{putCode: http.StatusOK}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/scans/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.record(&s.presign, r, body)
+
+		code, payload := http.StatusOK, any(signedUploadResponse{
+			UploadURL: s.srv.URL + "/objects/scan-log.jsonl.gz",
+			Method:    http.MethodPut,
+			Headers:   map[string]string{"Content-Type": "application/octet-stream"},
+		})
+		if s.response != nil {
+			code, payload = s.response(s.srv.URL + "/objects/scan-log.jsonl.gz")
+		}
+		w.WriteHeader(code)
+		if raw, ok := payload.(string); ok {
+			_, _ = w.Write([]byte(raw))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+
+	mux.HandleFunc("/objects/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.record(&s.put, r, body)
+		w.WriteHeader(s.putCode)
+		if s.putBody != "" {
+			_, _ = w.Write([]byte(s.putBody))
+		}
+	})
+
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+
+	t.Setenv("PDCP_API_SERVER", s.srv.URL)
+	t.Setenv("PDCP_API_KEY", "test-api-key")
+	t.Setenv("PROXY_URL", "")
+
+	return s
+}
+
+func (s *scanLogServer) record(into *[]recordedRequest, r *http.Request, body []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	*into = append(*into, recordedRequest{
+		method:        r.Method,
+		path:          r.URL.Path,
+		rawQuery:      r.URL.RawQuery,
+		header:        r.Header.Clone(),
+		body:          body,
+		contentLength: r.ContentLength,
+	})
+}
+
+func (s *scanLogServer) presigns() []recordedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedRequest(nil), s.presign...)
+}
+
+func (s *scanLogServer) puts() []recordedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedRequest(nil), s.put...)
+}
+
+func writeOutput(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "chunk.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write output: %v", err)
+	}
+	return path
+}
+
+func testTask() *types.Task {
+	return &types.Task{
+		Id: "chunk-abc123",
+		Options: types.Options{
+			TeamID:    "team-1",
+			ScanID:    "scan-9",
+			HistoryID: 42,
+		},
+	}
+}
+
+func gunzip(t *testing.T, b []byte) string {
+	t.Helper()
+	zr, err := gzip.NewReader(strings.NewReader(string(b)))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+	out, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	return string(out)
+}
+
+func TestUploadNucleiOutputViaSignedURL(t *testing.T) {
+	srv := newScanLogServer(t)
+	outputFile := writeOutput(t, testScanLogLine)
+	task := testTask()
+
+	if err := uploadNucleiOutputViaSignedURL(context.Background(), task, outputFile); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	presigns := srv.presigns()
+	if len(presigns) != 1 {
+		t.Fatalf("presign requests = %d, want 1", len(presigns))
+	}
+	p := presigns[0]
+	if p.method != http.MethodPost {
+		t.Errorf("presign method = %s, want POST", p.method)
+	}
+	if want := "/v1/scans/scan-9/scan_log/upload-url"; p.path != want {
+		t.Errorf("presign path = %s, want %s", p.path, want)
+	}
+	if want := "history_id=42"; p.rawQuery != want {
+		t.Errorf("presign query = %s, want %s", p.rawQuery, want)
+	}
+	if got := p.header.Get("X-Api-Key"); got != "test-api-key" {
+		t.Errorf("presign X-Api-Key = %q, want test-api-key", got)
+	}
+	if got := p.header.Get("X-Team-Id"); got != "team-1" {
+		t.Errorf("presign X-Team-Id = %q, want team-1", got)
+	}
+	if got := p.header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("presign Content-Type = %q, want application/json", got)
+	}
+	var reqBody map[string]string
+	if err := json.Unmarshal(p.body, &reqBody); err != nil {
+		t.Fatalf("presign body not JSON: %v", err)
+	}
+	if want := "chunk-abc123.jsonl.gz"; reqBody["filename"] != want {
+		t.Errorf("presign filename = %q, want %q", reqBody["filename"], want)
+	}
+
+	puts := srv.puts()
+	if len(puts) != 1 {
+		t.Fatalf("PUT requests = %d, want 1", len(puts))
+	}
+	u := puts[0]
+	if u.method != http.MethodPut {
+		t.Errorf("PUT method = %s, want PUT", u.method)
+	}
+	if got := u.header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("PUT Content-Type = %q, want the signed header verbatim", got)
+	}
+	if u.contentLength != int64(len(u.body)) {
+		t.Errorf("PUT Content-Length = %d, want %d", u.contentLength, len(u.body))
+	}
+	if u.contentLength <= 0 {
+		t.Error("PUT sent no Content-Length; signed URLs reject chunked bodies")
+	}
+	if got := gunzip(t, u.body); got != testScanLogLine {
+		t.Errorf("uploaded payload = %q, want %q", got, testScanLogLine)
+	}
+
+	// The gz temp lives beside the output file; a leaked one would pile up per chunk.
+	entries, err := os.ReadDir(filepath.Dir(outputFile))
+	if err != nil {
+		t.Fatalf("read output dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".gz") {
+			t.Errorf("leftover gz temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestUploadNucleiOutputViaSignedURLEmptyFile(t *testing.T) {
+	srv := newScanLogServer(t)
+	outputFile := writeOutput(t, "")
+
+	if err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if n := len(srv.presigns()); n != 0 {
+		t.Errorf("presign requests = %d, want 0 for an empty output", n)
+	}
+	if n := len(srv.puts()); n != 0 {
+		t.Errorf("PUT requests = %d, want 0 for an empty output", n)
+	}
+}
+
+func TestUploadNucleiOutputViaSignedURLMissingFile(t *testing.T) {
+	newScanLogServer(t)
+	missing := filepath.Join(t.TempDir(), "absent.jsonl")
+
+	err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), missing)
+	if err == nil {
+		t.Fatal("expected an error for a missing output file")
+	}
+	if !strings.Contains(err.Error(), "stat output") {
+		t.Errorf("error = %v, want it to mention stat output", err)
+	}
+}
+
+func TestUploadNucleiOutputViaSignedURLPresignFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		response func(putURL string) (int, any)
+		wantErr  string
+	}{
+		{
+			name:     "non-200 status",
+			response: func(string) (int, any) { return http.StatusForbidden, "storage not provisioned" },
+			wantErr:  "upload-url status 403",
+		},
+		{
+			name:     "unparseable body",
+			response: func(string) (int, any) { return http.StatusOK, "not json" },
+			wantErr:  "decode upload-url response",
+		},
+		{
+			name:     "missing url",
+			response: func(string) (int, any) { return http.StatusOK, signedUploadResponse{Method: http.MethodPut} },
+			wantErr:  "missing url/method",
+		},
+		{
+			name: "missing method",
+			response: func(putURL string) (int, any) {
+				return http.StatusOK, signedUploadResponse{UploadURL: putURL}
+			},
+			wantErr: "missing url/method",
+		},
+		{
+			name: "payload over max_bytes",
+			response: func(putURL string) (int, any) {
+				return http.StatusOK, signedUploadResponse{UploadURL: putURL, Method: http.MethodPut, MaxBytes: 1}
+			},
+			wantErr: "exceeds signed-url max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newScanLogServer(t)
+			srv.response = tt.response
+			outputFile := writeOutput(t, testScanLogLine)
+
+			err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+			if n := len(srv.puts()); n != 0 {
+				t.Errorf("PUT requests = %d, want 0 when presign fails", n)
+			}
+		})
+	}
+}
+
+func TestUploadNucleiOutputViaSignedURLPutStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    int
+		body    string
+		wantErr string
+	}{
+		{name: "200 accepted", code: http.StatusOK},
+		{name: "201 accepted", code: http.StatusCreated},
+		{name: "403 rejected", code: http.StatusForbidden, body: "SignatureDoesNotMatch", wantErr: "PUT status 403"},
+		{name: "500 rejected", code: http.StatusInternalServerError, body: "boom", wantErr: "PUT status 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newScanLogServer(t)
+			srv.putCode = tt.code
+			srv.putBody = tt.body
+			outputFile := writeOutput(t, testScanLogLine)
+
+			err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("upload: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("expected an error containing %q", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// A transport failure must not put the signed URL's HMAC query into the error.
+func TestUploadNucleiOutputViaSignedURLDoesNotLeakSignature(t *testing.T) {
+	const signature = "0123456789abcdefdeadbeef"
+
+	srv := newScanLogServer(t)
+	srv.response = func(string) (int, any) {
+		return http.StatusOK, signedUploadResponse{
+			// Port 1 refuses fast, forcing a *url.Error through stripSignedURL.
+			UploadURL: "http://127.0.0.1:1/bucket/obj.gz?X-Amz-Signature=" + signature,
+			Method:    http.MethodPut,
+		}
+	}
+	outputFile := writeOutput(t, testScanLogLine)
+
+	err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if strings.Contains(err.Error(), signature) {
+		t.Errorf("error leaked the URL signature: %v", err)
+	}
+	if !strings.Contains(err.Error(), "PUT:") {
+		t.Errorf("error = %v, want it to name the failed operation", err)
+	}
+}
+
+func TestStripSignedURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		want    string
+		notWant string
+	}{
+		{
+			name: "url error drops the url",
+			err: &url.Error{
+				Op:  "Put",
+				URL: "https://bucket.s3.amazonaws.com/o?X-Amz-Signature=secret",
+				Err: errors.New("connection refused"),
+			},
+			want:    "Put: connection refused",
+			notWant: "secret",
+		},
+		{
+			name: "wrapped url error is unwrapped",
+			err: fmt.Errorf("PUT: %w", &url.Error{
+				Op:  "Put",
+				URL: "https://bucket/o?X-Amz-Signature=secret",
+				Err: errors.New("timeout"),
+			}),
+			want:    "Put: timeout",
+			notWant: "secret",
+		},
+		{
+			name: "plain error passes through",
+			err:  errors.New("no signature here"),
+			want: "no signature here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripSignedURL(tt.err)
+			if got != tt.want {
+				t.Errorf("stripSignedURL() = %q, want %q", got, tt.want)
+			}
+			if tt.notWant != "" && strings.Contains(got, tt.notWant) {
+				t.Errorf("stripSignedURL() = %q, must not contain %q", got, tt.notWant)
+			}
+		})
+	}
+}
+
+func TestGzipFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in.jsonl")
+	dst := filepath.Join(dir, "out.gz")
+
+	content := strings.Repeat(testScanLogLine, 200)
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	size, err := gzipFile(src, dst)
+	if err != nil {
+		t.Fatalf("gzipFile: %v", err)
+	}
+
+	st, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if size != st.Size() {
+		t.Errorf("returned size = %d, want %d", size, st.Size())
+	}
+	if size >= int64(len(content)) {
+		t.Errorf("gz size %d not smaller than raw %d", size, len(content))
+	}
+
+	raw, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if got := gunzip(t, raw); got != content {
+		t.Error("round-tripped content differs from source")
+	}
+}
+
+func TestGzipFileMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := gzipFile(filepath.Join(dir, "absent"), filepath.Join(dir, "out.gz")); err == nil {
+		t.Fatal("expected an error for a missing source")
+	}
+}

--- a/pkg/portfilter.go
+++ b/pkg/portfilter.go
@@ -321,6 +321,11 @@ var cachedTemplateDir string
 var templateDirOnce sync.Once
 
 // GetNucleiDefaultTemplateDir returns the default nuclei template directory, cached.
+//
+// The cache is primed at boot by ensureNucleiTemplates, before a staged install
+// can repoint the underlying global at a temporary directory. Calling this for
+// the first time during an install would cache a path that is about to be
+// deleted, so keep the boot-time call first.
 func GetNucleiDefaultTemplateDir() string {
 	templateDirOnce.Do(func() {
 		if cfg := config.DefaultConfig; cfg != nil && cfg.TemplatesDirectory != "" {

--- a/pkg/runtools/nuclei.go
+++ b/pkg/runtools/nuclei.go
@@ -11,19 +11,8 @@ import (
 	"sync"
 
 	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
-	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
 )
-
-// UpdateNucleiTemplates installs nuclei-templates if missing, otherwise
-// updates them. Idempotent.
-func UpdateNucleiTemplates() error {
-	tm := &installer.TemplateManager{}
-	if err := tm.UpdateIfOutdated(); err != nil {
-		return fmt.Errorf("update nuclei templates: %w", err)
-	}
-	return nil
-}
 
 // NucleiOptions configures an embedded nuclei scan.
 type NucleiOptions struct {

--- a/pkg/runtools/nuclei.go
+++ b/pkg/runtools/nuclei.go
@@ -104,11 +104,22 @@ func RunNuclei(ctx context.Context, opts NucleiOptions) (string, error) {
 		sdkOpts = append(sdkOpts, nuclei.WithPDCPUpload(opts.ScanID, opts.TeamID))
 	}
 
+	// Templates are read from a directory a repair can replace. Hold the read
+	// lock across engine setup and the load so a swap cannot land mid-walk, and
+	// load explicitly: the SDK's lazy load discards its error and a partial set
+	// would otherwise scan clean.
+	templateRW.RLock()
 	ne, err := nuclei.NewNucleiEngineCtx(ctx, sdkOpts...)
 	if err != nil {
+		templateRW.RUnlock()
 		return opts.OutputFile, fmt.Errorf("init nuclei engine: %w", err)
 	}
 	defer ne.Close()
+	loadErr := ne.LoadAllTemplates()
+	templateRW.RUnlock()
+	if loadErr != nil {
+		return opts.OutputFile, fmt.Errorf("load templates: %w", loadErr)
+	}
 
 	ne.LoadTargets(opts.Targets, opts.ProbeNonHttp)
 

--- a/pkg/runtools/nuclei.go
+++ b/pkg/runtools/nuclei.go
@@ -20,7 +20,8 @@ type NucleiOptions struct {
 	OutputFile string
 	// Targets is the list of hosts/URLs to scan. Required.
 	Targets []string
-	// Templates lists template paths or IDs; empty runs the default set.
+	// Templates lists template file or directory paths, globs included; empty
+	// runs the default set. Template IDs are a separate nuclei option.
 	Templates []string
 	// ScanID and TeamID stamp dashboard-upload metadata into output.
 	ScanID               string

--- a/pkg/runtools/nuclei_bootstrap.go
+++ b/pkg/runtools/nuclei_bootstrap.go
@@ -3,7 +3,6 @@ package runtools
 import (
 	"sync"
 
-	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
 )
 
@@ -13,7 +12,9 @@ var nucleiBootstrapOnce sync.Once
 // process-wide, so per-scan toggling risks a write race with concurrent scans.
 func InitNucleiProcess() {
 	nucleiBootstrapOnce.Do(func() {
-		nuclei.DefaultConfig.DisableUpdateCheck()
+		// DisableUpdateCheck() is deliberately NOT called: it is a one-way
+		// process-global that short-circuits NeedsTemplateUpdate(), which
+		// silently pinned agents to whatever release they booted with.
 		// Defaults to true upstream; pin in case that flips.
 		installer.HideReleaseNotes = true
 	})

--- a/pkg/runtools/nuclei_bootstrap.go
+++ b/pkg/runtools/nuclei_bootstrap.go
@@ -3,6 +3,8 @@ package runtools
 import (
 	"sync"
 
+	nuclei "github.com/projectdiscovery/nuclei/v3/lib"
+
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
 )
 
@@ -12,9 +14,12 @@ var nucleiBootstrapOnce sync.Once
 // process-wide, so per-scan toggling risks a write race with concurrent scans.
 func InitNucleiProcess() {
 	nucleiBootstrapOnce.Do(func() {
-		// DisableUpdateCheck() is deliberately NOT called: it is a one-way
-		// process-global that short-circuits NeedsTemplateUpdate(), which
-		// silently pinned agents to whatever release they booted with.
+		// Engine init runs UpdateIfOutdated, which writes the shared template
+		// directory without taking templateRW, so a concurrent chunk can load a
+		// half-updated set and report a clean scan. Updates are ours: a staged
+		// install under the write lock. Disabling is one-way, so nothing here
+		// may rely on nuclei's updater afterwards.
+		nuclei.DefaultConfig.DisableUpdateCheck()
 		// Defaults to true upstream; pin in case that flips.
 		installer.HideReleaseNotes = true
 	})

--- a/pkg/runtools/templates.go
+++ b/pkg/runtools/templates.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -42,9 +43,10 @@ var ErrGitHubRateLimited = errors.New("github api rate limit exhausted")
 // timeout, and this call gates agent startup.
 var latestTagClient = &http.Client{Timeout: latestTagTimeout}
 
-// templateMu serializes every read-modify-write of the shared template
-// directory: concurrent scans must not update and reinstall at once.
-var templateMu sync.Mutex
+// templateRW guards the shared template directory. Repairs and updates take
+// the write lock; nuclei takes the read lock while loading templates, so a
+// swap can never land mid-load and hand a scan a partial set.
+var templateRW sync.RWMutex
 
 var (
 	latestTagMu sync.Mutex
@@ -58,10 +60,11 @@ var (
 
 // Swappable for tests; the real ones download ~150MB or hit the network.
 var (
-	fetchLatestTag    = fetchLatestTagFromGitHub
-	incrementalUpdate = func() error { return (&installer.TemplateManager{}).UpdateIfOutdated() }
-	freshInstall      = func() error { return (&installer.TemplateManager{}).FreshInstallIfNotExists() }
-	nowFn             = time.Now
+	fetchLatestTag       = fetchLatestTagFromGitHub
+	incrementalUpdate    = func() error { return (&installer.TemplateManager{}).UpdateIfOutdated() }
+	freshInstall         = func() error { return (&installer.TemplateManager{}).FreshInstallIfNotExists() }
+	writeTemplatesConfig = func() error { return config.DefaultConfig.WriteTemplatesConfig() }
+	nowFn                = time.Now
 )
 
 // TemplateDir returns the directory nuclei loads public templates from.
@@ -221,45 +224,132 @@ func safeToReplace(dir string) error {
 	return nil
 }
 
-// reinstallTemplates discards the template directory and downloads the current
-// release. It is the only repair for a recorded version that is current while
-// files are absent, and it runs regardless of nuclei's update-check flag
-// (FreshInstallIfNotExists gates on directory existence, not that flag). The
-// old directory moves aside first so a failed download leaves templates intact.
+// downloadInto installs the current release into staging. FreshInstallIfNotExists
+// has no per-call directory, so nuclei's configured path is pointed at staging
+// for the download. WriteTemplatesConfig marshals the whole config, so the real
+// path is written back afterwards or the next boot would look for staging.
+func downloadInto(staging string) error {
+	live := config.DefaultConfig.TemplatesDirectory
+	config.DefaultConfig.TemplatesDirectory = staging
+	installErr := freshInstall()
+	config.DefaultConfig.TemplatesDirectory = live
+
+	if err := writeTemplatesConfig(); err != nil {
+		slog.Warn("nuclei templates: could not restore the template path in nuclei's config",
+			"path", live, "error", err)
+	}
+	if installErr != nil {
+		return fmt.Errorf("download templates: %w", installErr)
+	}
+	if !dirHasTemplates(staging) {
+		return fmt.Errorf("downloaded set at %s contains no templates", staging)
+	}
+	return nil
+}
+
+// dirHasTemplates reports whether dir holds at least one template, so an empty
+// download is never swapped over a working set.
+func dirHasTemplates(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(path, ".yaml") {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// installFreshSet downloads the current release into a sibling directory and
+// swaps it in. Downloading in place would leave the live directory half-written
+// for the length of the download; here it is only ever replaced by a complete
+// set, and the previous set is kept until the swap succeeds.
 //
-// Callers must hold templateMu.
-func reinstallTemplates() error {
+// Callers must hold templateRW for writing.
+func installFreshSet() error {
 	dir := TemplateDir()
 	if err := safeToReplace(dir); err != nil {
 		return err
 	}
 
-	aside := dir + ".stale-" + strconv.Itoa(os.Getpid())
-	_ = os.RemoveAll(aside)
+	pid := strconv.Itoa(os.Getpid())
+	staging, retired := dir+".incoming-"+pid, dir+".retired-"+pid
+	_ = os.RemoveAll(staging)
+	_ = os.RemoveAll(retired)
+	defer func() {
+		_ = os.RemoveAll(staging)
+		_ = os.RemoveAll(retired)
+	}()
+
+	slog.Info("nuclei templates: download started", "staging", staging)
+	start := nowFn()
+	if err := downloadInto(staging); err != nil {
+		return err
+	}
 
 	moved := false
 	if _, err := os.Stat(dir); err == nil {
-		if err := os.Rename(dir, aside); err != nil {
-			return fmt.Errorf("move stale templates aside: %w", err)
+		if err := os.Rename(dir, retired); err != nil {
+			return fmt.Errorf("retire the previous template set: %w", err)
 		}
 		moved = true
 	}
-
-	slog.Info("nuclei templates: reinstall started", "path", dir)
-	start := nowFn()
-	if err := freshInstall(); err != nil {
+	if err := os.Rename(staging, dir); err != nil {
 		if moved {
-			_ = os.RemoveAll(dir)
-			_ = os.Rename(aside, dir)
+			if restoreErr := os.Rename(retired, dir); restoreErr != nil {
+				slog.Error("nuclei templates: no template set on disk, restore failed",
+					"path", dir, "retired", retired, "error", restoreErr)
+			}
 		}
-		return fmt.Errorf("fresh install templates: %w", err)
+		return fmt.Errorf("swap the new template set into place: %w", err)
 	}
-	if moved {
-		_ = os.RemoveAll(aside)
-	}
-	slog.Info("nuclei templates: reinstall finished",
+
+	slog.Info("nuclei templates: download finished",
 		"path", dir, "version", InstalledTemplateVersion(), "duration", nowFn().Sub(start))
 	return nil
+}
+
+var (
+	repairMu          sync.Mutex
+	repairWanted      bool
+	repairReason      string
+	repairedAtVersion string
+)
+
+// RequestTemplateRepair marks the on-disk set as suspect so the next scan-level
+// refresh reinstalls it before any chunk runs. A repair already attempted at the
+// current release is not retried: reinstalling the same release cannot produce a
+// template that release does not contain.
+func RequestTemplateRepair(reason string) {
+	repairMu.Lock()
+	defer repairMu.Unlock()
+
+	if installed := InstalledTemplateVersion(); installed != "" && installed == repairedAtVersion {
+		slog.Debug("nuclei templates: repair already attempted at this release, not retrying",
+			"version", installed, "reason", reason)
+		return
+	}
+	if !repairWanted {
+		slog.Warn("nuclei templates: repair queued for the next scan", "reason", reason)
+	}
+	repairWanted, repairReason = true, reason
+}
+
+func takeRepairRequest() (string, bool) {
+	repairMu.Lock()
+	defer repairMu.Unlock()
+	return repairReason, repairWanted
+}
+
+func markRepaired() {
+	repairMu.Lock()
+	defer repairMu.Unlock()
+	repairWanted, repairReason = false, ""
+	repairedAtVersion = InstalledTemplateVersion()
 }
 
 // EnsureLatestTemplates brings the template set to the newest published
@@ -267,8 +357,8 @@ func reinstallTemplates() error {
 // installed; a lagging one is updated incrementally; an update that fails to
 // land the expected version falls back to a full reinstall.
 func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
-	templateMu.Lock()
-	defer templateMu.Unlock()
+	templateRW.Lock()
+	defer templateRW.Unlock()
 
 	from = InstalledTemplateVersion()
 
@@ -280,6 +370,15 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 		if err := freshInstall(); err != nil {
 			return from, from, fmt.Errorf("install templates: %w", err)
 		}
+		return from, InstalledTemplateVersion(), nil
+	}
+
+	if reason, wanted := takeRepairRequest(); wanted {
+		slog.Warn("nuclei templates: reinstalling before the scan", "reason", reason)
+		if err := installFreshSet(); err != nil {
+			return from, InstalledTemplateVersion(), err
+		}
+		markRepaired()
 		return from, InstalledTemplateVersion(), nil
 	}
 
@@ -306,13 +405,13 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 	if updateErr := incrementalUpdate(); updateErr != nil {
 		slog.Warn("nuclei templates: incremental update failed, reinstalling",
 			"from", from, "to", latest, "error", updateErr)
-		if err := reinstallTemplates(); err != nil {
+		if err := installFreshSet(); err != nil {
 			return from, InstalledTemplateVersion(), err
 		}
 	} else if got := InstalledTemplateVersion(); got != latest {
 		slog.Warn("nuclei templates: update did not land the expected version, reinstalling",
 			"want", latest, "got", got)
-		if err := reinstallTemplates(); err != nil {
+		if err := installFreshSet(); err != nil {
 			return from, InstalledTemplateVersion(), err
 		}
 	}
@@ -325,42 +424,9 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 	return from, to, nil
 }
 
-// EnsureTemplatesFor guarantees every required public template is on disk.
-// Version equality is not enough: a set at the newest release can still be
-// missing files, and only a reinstall repairs that. Returns the paths still
-// missing after the repair attempt.
-func EnsureTemplatesFor(ctx context.Context, required []string) ([]string, error) {
-	if missing := MissingTemplates(required); len(missing) == 0 {
-		return nil, nil
-	}
-
-	templateMu.Lock()
-	defer templateMu.Unlock()
-
-	// Re-check under the lock: a concurrent chunk may have just repaired it.
-	missing := MissingTemplates(required)
-	if len(missing) == 0 {
-		return nil, nil
-	}
-
-	slog.Warn("nuclei templates: requested templates missing, repairing",
-		"missing_count", len(missing), "sample", sample(missing, 3),
-		"installed_version", InstalledTemplateVersion())
-
-	if err := reinstallTemplates(); err != nil {
-		return missing, err
-	}
-
-	if stillMissing := MissingTemplates(required); len(stillMissing) > 0 {
-		return stillMissing, fmt.Errorf("%d requested templates absent from %s after reinstall",
-			len(stillMissing), InstalledTemplateVersion())
-	}
-	return nil, nil
-}
-
-func sample(items []string, n int) []string {
-	if len(items) <= n {
-		return items
-	}
-	return items[:n]
+// VerifyTemplatesFor returns the requested public templates missing from disk.
+// It never installs: repairs belong at scan scope, before chunks launch, so a
+// bad set cannot have every chunk re-downloading the shared directory.
+func VerifyTemplatesFor(required []string) []string {
+	return MissingTemplates(required)
 }

--- a/pkg/runtools/templates.go
+++ b/pkg/runtools/templates.go
@@ -62,14 +62,23 @@ var (
 // Swappable for tests; the real ones download ~150MB or hit the network.
 var (
 	fetchLatestTag       = fetchLatestTagFromGitHub
-	incrementalUpdate    = func() error { return (&installer.TemplateManager{}).UpdateIfOutdated() }
 	freshInstall         = func() error { return (&installer.TemplateManager{}).FreshInstallIfNotExists() }
 	writeTemplatesConfig = func() error { return config.DefaultConfig.WriteTemplatesConfig() }
 	nowFn                = time.Now
 )
 
-// TemplateDir returns the directory nuclei loads public templates from.
-func TemplateDir() string { return config.DefaultConfig.TemplatesDirectory }
+// TemplateDir returns the directory nuclei loads public templates from. It
+// takes the read lock: a staged install repoints this global while it downloads,
+// so an unlocked reader can see a path that is about to be deleted.
+func TemplateDir() string {
+	templateRW.RLock()
+	defer templateRW.RUnlock()
+	return templateDir()
+}
+
+// templateDir reads the global without locking, for callers already holding
+// templateRW.
+func templateDir() string { return config.DefaultConfig.TemplatesDirectory }
 
 // InstalledTemplateVersion returns the release nuclei recorded on disk. It is
 // advisory only: the version can be current while files are missing.
@@ -182,12 +191,12 @@ func LastKnownTemplateTag() (string, time.Time) {
 	return latestTag, latestTagAt
 }
 
-// MissingTemplates returns the requested definitions nuclei cannot resolve. It
+// missingTemplates returns the requested definitions nuclei cannot resolve. It
 // defers to nuclei's own resolver rather than stat'ing paths: the resolver globs,
 // walks directories and resolves relative paths, so a stat loop reports a glob
 // entry as missing while the scan expands it happily.
-func MissingTemplates(required []string) []string {
-	dir := TemplateDir()
+func missingTemplates(required []string) []string {
+	dir := templateDir()
 	if dir == "" || len(required) == 0 {
 		return nil
 	}
@@ -295,7 +304,7 @@ func dirHasTemplates(dir string) bool {
 //
 // Callers must hold templateRW for writing.
 func installFreshSet() error {
-	dir := TemplateDir()
+	dir := templateDir()
 	if err := safeToReplace(dir); err != nil {
 		return err
 	}
@@ -386,12 +395,12 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 
 	from = InstalledTemplateVersion()
 
-	dir := TemplateDir()
+	dir := templateDir()
 	if dir == "" {
 		return from, from, fmt.Errorf("could not determine nuclei template directory")
 	}
 	if _, statErr := os.Stat(dir); statErr != nil {
-		if err := freshInstall(); err != nil {
+		if err := installFreshSet(); err != nil {
 			return from, from, fmt.Errorf("install templates: %w", err)
 		}
 		return from, InstalledTemplateVersion(), nil
@@ -420,24 +429,13 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 		return from, latest, nil
 	}
 
-	// Hand nuclei the real latest version: its own cached value is what makes
-	// NeedsTemplateUpdate report "current" while releases behind.
-	config.DefaultConfig.LatestNucleiTemplatesVersion = latest
-
+	// A staged install is the only writer: nuclei's own incremental update is
+	// disabled process-wide because it writes the directory without taking this
+	// lock. A full install measures ~6s, so there is nothing to gain from it.
 	slog.Info("nuclei templates: update started", "from", from, "to", latest)
 	start := nowFn()
-	if updateErr := incrementalUpdate(); updateErr != nil {
-		slog.Warn("nuclei templates: incremental update failed, reinstalling",
-			"from", from, "to", latest, "error", updateErr)
-		if err := installFreshSet(); err != nil {
-			return from, InstalledTemplateVersion(), err
-		}
-	} else if got := InstalledTemplateVersion(); got != latest {
-		slog.Warn("nuclei templates: update did not land the expected version, reinstalling",
-			"want", latest, "got", got)
-		if err := installFreshSet(); err != nil {
-			return from, InstalledTemplateVersion(), err
-		}
+	if err := installFreshSet(); err != nil {
+		return from, InstalledTemplateVersion(), err
 	}
 
 	to = InstalledTemplateVersion()
@@ -452,5 +450,7 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 // It never installs: repairs belong at scan scope, before chunks launch, so a
 // bad set cannot have every chunk re-downloading the shared directory.
 func VerifyTemplatesFor(required []string) []string {
-	return MissingTemplates(required)
+	templateRW.RLock()
+	defer templateRW.RUnlock()
+	return missingTemplates(required)
 }

--- a/pkg/runtools/templates.go
+++ b/pkg/runtools/templates.go
@@ -19,11 +19,13 @@ import (
 	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
 )
 
+// templatesLatestURL is a var only so tests can point it at httptest.
+var templatesLatestURL = "https://api.github.com/repos/projectdiscovery/nuclei-templates/releases/latest"
+
 const (
-	templatesLatestURL = "https://api.github.com/repos/projectdiscovery/nuclei-templates/releases/latest"
-	latestTagTTL       = 15 * time.Minute
-	latestTagFailTTL   = 2 * time.Minute
-	latestTagTimeout   = 30 * time.Second
+	latestTagTTL     = 15 * time.Minute
+	latestTagFailTTL = 2 * time.Minute
+	latestTagTimeout = 30 * time.Second
 )
 
 // ErrFreshnessUnknown reports that the newest release could not be resolved.
@@ -45,9 +47,12 @@ var latestTagClient = &http.Client{Timeout: latestTagTimeout}
 var templateMu sync.Mutex
 
 var (
-	latestTagMu  sync.Mutex
-	latestTag    string
-	latestTagAt  time.Time
+	latestTagMu sync.Mutex
+	latestTag   string    // last tag resolved successfully
+	latestTagAt time.Time // when latestTag was resolved
+	// latestTagTry is the last attempt, successful or not. Separate from
+	// latestTagAt so a retained stale tag is never served as if it were fresh.
+	latestTagTry time.Time
 	latestTagErr error
 )
 
@@ -109,7 +114,12 @@ func isRateLimited(resp *http.Response) bool {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
 		return false
 	}
-	return resp.Header.Get("X-RateLimit-Remaining") == "0"
+	if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		return true
+	}
+	// Secondary limits leave X-RateLimit-Remaining untouched and answer with
+	// Retry-After instead.
+	return resp.Header.Get("Retry-After") != ""
 }
 
 // rateLimitAdvice names the fix and, when GitHub says so, when the quota returns.
@@ -119,6 +129,8 @@ func rateLimitAdvice(resp *http.Response) string {
 		if wait := time.Until(time.Unix(sec, 0)); wait > 0 {
 			fmt.Fprintf(&b, ", resets in %s", wait.Round(time.Second))
 		}
+	} else if retry := resp.Header.Get("Retry-After"); retry != "" {
+		fmt.Fprintf(&b, ", retry after %ss", retry)
 	}
 	if envconfig.GitHubToken() == "" {
 		fmt.Fprintf(&b, "; set %s to raise the limit from 60/hr per IP to 5000/hr", envconfig.KeyGitHubToken)
@@ -141,18 +153,29 @@ func LatestTemplateTag(ctx context.Context) (string, error) {
 	}
 	// Cache failures too, briefly: without this a rate-limited fleet retries on
 	// every scan and keeps its own quota exhausted.
-	if latestTagErr != nil && nowFn().Sub(latestTagAt) < latestTagFailTTL {
+	if latestTagErr != nil && nowFn().Sub(latestTagTry) < latestTagFailTTL {
 		return "", latestTagErr
 	}
 
+	latestTagTry = nowFn()
 	tag, err := fetchLatestTag(ctx)
 	if err != nil {
-		latestTag, latestTagAt = "", nowFn()
+		// latestTag is deliberately kept: a tag resolved minutes ago is still
+		// the best comparison available, and callers may fall back to it.
 		latestTagErr = fmt.Errorf("%w: %w", ErrFreshnessUnknown, err)
 		return "", latestTagErr
 	}
 	latestTag, latestTagAt, latestTagErr = tag, nowFn(), nil
 	return tag, nil
+}
+
+// LastKnownTemplateTag returns the most recent successfully resolved release
+// and when it was resolved, so a caller can still compare versions while the
+// release API is unreachable. Empty when no lookup has ever succeeded.
+func LastKnownTemplateTag() (string, time.Time) {
+	latestTagMu.Lock()
+	defer latestTagMu.Unlock()
+	return latestTag, latestTagAt
 }
 
 // MissingTemplates returns the repo-relative paths absent from the template
@@ -198,12 +221,14 @@ func safeToReplace(dir string) error {
 	return nil
 }
 
-// ReinstallTemplates discards the template directory and downloads the current
+// reinstallTemplates discards the template directory and downloads the current
 // release. It is the only repair for a recorded version that is current while
 // files are absent, and it runs regardless of nuclei's update-check flag
 // (FreshInstallIfNotExists gates on directory existence, not that flag). The
 // old directory moves aside first so a failed download leaves templates intact.
-func ReinstallTemplates(_ context.Context) error {
+//
+// Callers must hold templateMu.
+func reinstallTemplates() error {
 	dir := TemplateDir()
 	if err := safeToReplace(dir); err != nil {
 		return err
@@ -260,7 +285,13 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 
 	latest, err := LatestTemplateTag(ctx)
 	if err != nil {
-		return from, from, err
+		stale, at := LastKnownTemplateTag()
+		if stale == "" {
+			return from, from, err
+		}
+		slog.Warn("nuclei templates: release lookup failed, comparing against the last known release",
+			"release", stale, "resolved_ago", nowFn().Sub(at).Round(time.Second), "error", err)
+		latest = stale
 	}
 	if from == latest {
 		return from, latest, nil
@@ -275,13 +306,13 @@ func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
 	if updateErr := incrementalUpdate(); updateErr != nil {
 		slog.Warn("nuclei templates: incremental update failed, reinstalling",
 			"from", from, "to", latest, "error", updateErr)
-		if err := ReinstallTemplates(ctx); err != nil {
+		if err := reinstallTemplates(); err != nil {
 			return from, InstalledTemplateVersion(), err
 		}
 	} else if got := InstalledTemplateVersion(); got != latest {
 		slog.Warn("nuclei templates: update did not land the expected version, reinstalling",
 			"want", latest, "got", got)
-		if err := ReinstallTemplates(ctx); err != nil {
+		if err := reinstallTemplates(); err != nil {
 			return from, InstalledTemplateVersion(), err
 		}
 	}
@@ -316,7 +347,7 @@ func EnsureTemplatesFor(ctx context.Context, required []string) ([]string, error
 		"missing_count", len(missing), "sample", sample(missing, 3),
 		"installed_version", InstalledTemplateVersion())
 
-	if err := ReinstallTemplates(ctx); err != nil {
+	if err := reinstallTemplates(); err != nil {
 		return missing, err
 	}
 

--- a/pkg/runtools/templates.go
+++ b/pkg/runtools/templates.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/disk"
 	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
 	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
 )
@@ -181,25 +182,48 @@ func LastKnownTemplateTag() (string, time.Time) {
 	return latestTag, latestTagAt
 }
 
-// MissingTemplates returns the repo-relative paths absent from the template
-// directory. Absolute paths are skipped: private templates are materialized
-// into a per-chunk temp dir and are not part of the public set.
+// MissingTemplates returns the requested definitions nuclei cannot resolve. It
+// defers to nuclei's own resolver rather than stat'ing paths: the resolver globs,
+// walks directories and resolves relative paths, so a stat loop reports a glob
+// entry as missing while the scan expands it happily.
 func MissingTemplates(required []string) []string {
 	dir := TemplateDir()
-	if dir == "" {
+	if dir == "" || len(required) == 0 {
 		return nil
 	}
 
-	var missing []string
-	for _, path := range required {
-		if path == "" || filepath.IsAbs(path) {
+	_, errs := disk.NewCatalog(dir).GetTemplatesPath(required)
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// Walk the input, not the map: map order is random and these paths reach
+	// logs and error messages.
+	missing := make([]string, 0, len(errs))
+	seen := make(map[string]struct{}, len(errs))
+	for _, def := range required {
+		if _, bad := errs[def]; !bad {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(dir, path)); err != nil {
-			missing = append(missing, path)
+		if _, dup := seen[def]; dup {
+			continue
 		}
+		seen[def] = struct{}{}
+		missing = append(missing, def)
 	}
 	return missing
+}
+
+// AnyPublic reports whether any definition belongs to the shared template
+// directory. Private templates are absolute paths in a per-chunk temp dir, and
+// reinstalling the public set cannot conjure one of those.
+func AnyPublic(definitions []string) bool {
+	for _, def := range definitions {
+		if def != "" && !filepath.IsAbs(def) {
+			return true
+		}
+	}
+	return false
 }
 
 // safeToReplace rejects template directories that would make removal

--- a/pkg/runtools/templates.go
+++ b/pkg/runtools/templates.go
@@ -1,0 +1,335 @@
+package runtools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/nuclei/v3/pkg/installer"
+	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
+)
+
+const (
+	templatesLatestURL = "https://api.github.com/repos/projectdiscovery/nuclei-templates/releases/latest"
+	latestTagTTL       = 15 * time.Minute
+	latestTagFailTTL   = 2 * time.Minute
+	latestTagTimeout   = 30 * time.Second
+)
+
+// ErrFreshnessUnknown reports that the newest release could not be resolved.
+// Templates already on disk are untouched and remain usable, so callers that
+// only wanted an upgrade should log and continue rather than abort.
+var ErrFreshnessUnknown = errors.New("nuclei-templates freshness could not be verified")
+
+// ErrGitHubRateLimited is ErrFreshnessUnknown's actionable case: the request
+// was rejected for quota, which GITHUB_TOKEN raises from 60/hr per IP to
+// 5000/hr per token.
+var ErrGitHubRateLimited = errors.New("github api rate limit exhausted")
+
+// latestTagClient bounds the release lookup. http.DefaultClient has no
+// timeout, and this call gates agent startup.
+var latestTagClient = &http.Client{Timeout: latestTagTimeout}
+
+// templateMu serializes every read-modify-write of the shared template
+// directory: concurrent scans must not update and reinstall at once.
+var templateMu sync.Mutex
+
+var (
+	latestTagMu  sync.Mutex
+	latestTag    string
+	latestTagAt  time.Time
+	latestTagErr error
+)
+
+// Swappable for tests; the real ones download ~150MB or hit the network.
+var (
+	fetchLatestTag    = fetchLatestTagFromGitHub
+	incrementalUpdate = func() error { return (&installer.TemplateManager{}).UpdateIfOutdated() }
+	freshInstall      = func() error { return (&installer.TemplateManager{}).FreshInstallIfNotExists() }
+	nowFn             = time.Now
+)
+
+// TemplateDir returns the directory nuclei loads public templates from.
+func TemplateDir() string { return config.DefaultConfig.TemplatesDirectory }
+
+// InstalledTemplateVersion returns the release nuclei recorded on disk. It is
+// advisory only: the version can be current while files are missing.
+func InstalledTemplateVersion() string { return config.DefaultConfig.TemplateVersion }
+
+func fetchLatestTagFromGitHub(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, templatesLatestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// Same variable projectdiscovery/utils/update authenticates the template
+	// downloads with, so one token covers lookup and download alike.
+	if token := envconfig.GitHubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := latestTagClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if isRateLimited(resp) {
+		return "", fmt.Errorf("%w%s", ErrGitHubRateLimited, rateLimitAdvice(resp))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("releases/latest status %d", resp.StatusCode)
+	}
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", err
+	}
+	if release.TagName == "" {
+		return "", fmt.Errorf("releases/latest returned no tag_name")
+	}
+	return release.TagName, nil
+}
+
+// isRateLimited reports whether GitHub rejected the request for quota rather
+// than for the credential being wrong: a 403 alone is also how a bad token
+// reads, and the two need different advice.
+func isRateLimited(resp *http.Response) bool {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return false
+	}
+	return resp.Header.Get("X-RateLimit-Remaining") == "0"
+}
+
+// rateLimitAdvice names the fix and, when GitHub says so, when the quota returns.
+func rateLimitAdvice(resp *http.Response) string {
+	var b strings.Builder
+	if sec, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+		if wait := time.Until(time.Unix(sec, 0)); wait > 0 {
+			fmt.Fprintf(&b, ", resets in %s", wait.Round(time.Second))
+		}
+	}
+	if envconfig.GitHubToken() == "" {
+		fmt.Fprintf(&b, "; set %s to raise the limit from 60/hr per IP to 5000/hr", envconfig.KeyGitHubToken)
+	} else {
+		fmt.Fprintf(&b, "; the %s in use is also exhausted", envconfig.KeyGitHubToken)
+	}
+	return b.String()
+}
+
+// LatestTemplateTag returns the newest published nuclei-templates release,
+// cached for latestTagTTL to stay inside the unauthenticated API quota.
+// Deliberately not nuclei's cached "nuclei-templates-latest-version": the SDK
+// refreshes that only after the code that could act on it has already run.
+func LatestTemplateTag(ctx context.Context) (string, error) {
+	latestTagMu.Lock()
+	defer latestTagMu.Unlock()
+
+	if latestTag != "" && nowFn().Sub(latestTagAt) < latestTagTTL {
+		return latestTag, nil
+	}
+	// Cache failures too, briefly: without this a rate-limited fleet retries on
+	// every scan and keeps its own quota exhausted.
+	if latestTagErr != nil && nowFn().Sub(latestTagAt) < latestTagFailTTL {
+		return "", latestTagErr
+	}
+
+	tag, err := fetchLatestTag(ctx)
+	if err != nil {
+		latestTag, latestTagAt = "", nowFn()
+		latestTagErr = fmt.Errorf("%w: %w", ErrFreshnessUnknown, err)
+		return "", latestTagErr
+	}
+	latestTag, latestTagAt, latestTagErr = tag, nowFn(), nil
+	return tag, nil
+}
+
+// MissingTemplates returns the repo-relative paths absent from the template
+// directory. Absolute paths are skipped: private templates are materialized
+// into a per-chunk temp dir and are not part of the public set.
+func MissingTemplates(required []string) []string {
+	dir := TemplateDir()
+	if dir == "" {
+		return nil
+	}
+
+	var missing []string
+	for _, path := range required {
+		if path == "" || filepath.IsAbs(path) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, path)); err != nil {
+			missing = append(missing, path)
+		}
+	}
+	return missing
+}
+
+// safeToReplace rejects template directories that would make removal
+// catastrophic: a mistyped or empty config must never delete a home directory.
+func safeToReplace(dir string) error {
+	if dir == "" {
+		return fmt.Errorf("template directory is unset")
+	}
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("template directory %q is not absolute", dir)
+	}
+	clean := filepath.Clean(dir)
+	if clean == string(filepath.Separator) || clean == "." {
+		return fmt.Errorf("refusing to replace %q", clean)
+	}
+	if home, err := os.UserHomeDir(); err == nil && clean == filepath.Clean(home) {
+		return fmt.Errorf("refusing to replace the home directory %q", clean)
+	}
+	if len(strings.Split(strings.Trim(clean, string(filepath.Separator)), string(filepath.Separator))) < 2 {
+		return fmt.Errorf("refusing to replace top-level path %q", clean)
+	}
+	return nil
+}
+
+// ReinstallTemplates discards the template directory and downloads the current
+// release. It is the only repair for a recorded version that is current while
+// files are absent, and it runs regardless of nuclei's update-check flag
+// (FreshInstallIfNotExists gates on directory existence, not that flag). The
+// old directory moves aside first so a failed download leaves templates intact.
+func ReinstallTemplates(_ context.Context) error {
+	dir := TemplateDir()
+	if err := safeToReplace(dir); err != nil {
+		return err
+	}
+
+	aside := dir + ".stale-" + strconv.Itoa(os.Getpid())
+	_ = os.RemoveAll(aside)
+
+	moved := false
+	if _, err := os.Stat(dir); err == nil {
+		if err := os.Rename(dir, aside); err != nil {
+			return fmt.Errorf("move stale templates aside: %w", err)
+		}
+		moved = true
+	}
+
+	slog.Info("nuclei templates: reinstall started", "path", dir)
+	start := nowFn()
+	if err := freshInstall(); err != nil {
+		if moved {
+			_ = os.RemoveAll(dir)
+			_ = os.Rename(aside, dir)
+		}
+		return fmt.Errorf("fresh install templates: %w", err)
+	}
+	if moved {
+		_ = os.RemoveAll(aside)
+	}
+	slog.Info("nuclei templates: reinstall finished",
+		"path", dir, "version", InstalledTemplateVersion(), "duration", nowFn().Sub(start))
+	return nil
+}
+
+// EnsureLatestTemplates brings the template set to the newest published
+// release, returning the versions before and after. A missing directory is
+// installed; a lagging one is updated incrementally; an update that fails to
+// land the expected version falls back to a full reinstall.
+func EnsureLatestTemplates(ctx context.Context) (from, to string, err error) {
+	templateMu.Lock()
+	defer templateMu.Unlock()
+
+	from = InstalledTemplateVersion()
+
+	dir := TemplateDir()
+	if dir == "" {
+		return from, from, fmt.Errorf("could not determine nuclei template directory")
+	}
+	if _, statErr := os.Stat(dir); statErr != nil {
+		if err := freshInstall(); err != nil {
+			return from, from, fmt.Errorf("install templates: %w", err)
+		}
+		return from, InstalledTemplateVersion(), nil
+	}
+
+	latest, err := LatestTemplateTag(ctx)
+	if err != nil {
+		return from, from, err
+	}
+	if from == latest {
+		return from, latest, nil
+	}
+
+	// Hand nuclei the real latest version: its own cached value is what makes
+	// NeedsTemplateUpdate report "current" while releases behind.
+	config.DefaultConfig.LatestNucleiTemplatesVersion = latest
+
+	slog.Info("nuclei templates: update started", "from", from, "to", latest)
+	start := nowFn()
+	if updateErr := incrementalUpdate(); updateErr != nil {
+		slog.Warn("nuclei templates: incremental update failed, reinstalling",
+			"from", from, "to", latest, "error", updateErr)
+		if err := ReinstallTemplates(ctx); err != nil {
+			return from, InstalledTemplateVersion(), err
+		}
+	} else if got := InstalledTemplateVersion(); got != latest {
+		slog.Warn("nuclei templates: update did not land the expected version, reinstalling",
+			"want", latest, "got", got)
+		if err := ReinstallTemplates(ctx); err != nil {
+			return from, InstalledTemplateVersion(), err
+		}
+	}
+
+	to = InstalledTemplateVersion()
+	if to != latest {
+		return from, to, fmt.Errorf("templates still at %s after repair, want %s", to, latest)
+	}
+	slog.Info("nuclei templates: update finished", "from", from, "to", to, "duration", nowFn().Sub(start))
+	return from, to, nil
+}
+
+// EnsureTemplatesFor guarantees every required public template is on disk.
+// Version equality is not enough: a set at the newest release can still be
+// missing files, and only a reinstall repairs that. Returns the paths still
+// missing after the repair attempt.
+func EnsureTemplatesFor(ctx context.Context, required []string) ([]string, error) {
+	if missing := MissingTemplates(required); len(missing) == 0 {
+		return nil, nil
+	}
+
+	templateMu.Lock()
+	defer templateMu.Unlock()
+
+	// Re-check under the lock: a concurrent chunk may have just repaired it.
+	missing := MissingTemplates(required)
+	if len(missing) == 0 {
+		return nil, nil
+	}
+
+	slog.Warn("nuclei templates: requested templates missing, repairing",
+		"missing_count", len(missing), "sample", sample(missing, 3),
+		"installed_version", InstalledTemplateVersion())
+
+	if err := ReinstallTemplates(ctx); err != nil {
+		return missing, err
+	}
+
+	if stillMissing := MissingTemplates(required); len(stillMissing) > 0 {
+		return stillMissing, fmt.Errorf("%d requested templates absent from %s after reinstall",
+			len(stillMissing), InstalledTemplateVersion())
+	}
+	return nil, nil
+}
+
+func sample(items []string, n int) []string {
+	if len(items) <= n {
+		return items
+	}
+	return items[:n]
+}

--- a/pkg/runtools/templates_live_test.go
+++ b/pkg/runtools/templates_live_test.go
@@ -1,0 +1,40 @@
+package runtools
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestEnsureLatestTemplatesLive exercises the real release lookup and the real
+// installer against the machine's actual template directory. Opt-in: it reaches
+// the network and rewrites ~/nuclei-templates.
+//
+//	PD_TEST_TEMPLATES_LIVE=1 go test ./pkg/runtools/ -run Live -v
+func TestEnsureLatestTemplatesLive(t *testing.T) {
+	if os.Getenv("PD_TEST_TEMPLATES_LIVE") != "1" {
+		t.Skip("set PD_TEST_TEMPLATES_LIVE=1 to run against the real template dir")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	latest, err := LatestTemplateTag(ctx)
+	if err != nil {
+		t.Fatalf("LatestTemplateTag: %v", err)
+	}
+	t.Logf("template dir: %s", TemplateDir())
+	t.Logf("installed:    %s", InstalledTemplateVersion())
+	t.Logf("latest:       %s", latest)
+
+	from, to, err := EnsureLatestTemplates(ctx)
+	if err != nil {
+		t.Fatalf("EnsureLatestTemplates: %v", err)
+	}
+	t.Logf("result:       %s -> %s", from, to)
+
+	if to != latest {
+		t.Errorf("installed version = %s after ensure, want %s", to, latest)
+	}
+}

--- a/pkg/runtools/templates_live_test.go
+++ b/pkg/runtools/templates_live_test.go
@@ -2,9 +2,14 @@ package runtools
 
 import (
 	"context"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
 )
 
 // TestEnsureLatestTemplatesLive exercises the real release lookup and the real
@@ -37,4 +42,75 @@ func TestEnsureLatestTemplatesLive(t *testing.T) {
 	if to != latest {
 		t.Errorf("installed version = %s after ensure, want %s", to, latest)
 	}
+}
+
+// TestInstallFreshSetLive runs the real staged install against the machine's
+// actual template directory: a full download into a sibling, then the swap.
+// This is the path unit tests cannot cover, because stubbing the config writer
+// is what keeps them from rewriting nuclei's real config file.
+//
+//	PD_TEST_TEMPLATES_LIVE=1 go test ./pkg/runtools/ -run InstallFreshSetLive -v
+func TestInstallFreshSetLive(t *testing.T) {
+	if os.Getenv("PD_TEST_TEMPLATES_LIVE") != "1" {
+		t.Skip("set PD_TEST_TEMPLATES_LIVE=1 to run a real staged install")
+	}
+
+	dir := TemplateDir()
+	before := countYAML(t, dir)
+	t.Logf("before: %s at %s, %d templates", InstalledTemplateVersion(), dir, before)
+	if before == 0 {
+		t.Fatalf("no templates at %s; refusing to run", dir)
+	}
+
+	templateRW.Lock()
+	err := installFreshSet()
+	templateRW.Unlock()
+	if err != nil {
+		t.Fatalf("installFreshSet: %v", err)
+	}
+
+	after := countYAML(t, dir)
+	t.Logf("after:  %s at %s, %d templates", InstalledTemplateVersion(), dir, after)
+	if after == 0 {
+		t.Fatal("template directory is empty after the swap")
+	}
+	if after < before/2 {
+		t.Errorf("template count collapsed: %d -> %d", before, after)
+	}
+
+	// The staging path must not survive anywhere: not on disk, not in the config.
+	for _, glob := range []string{dir + ".incoming-*", dir + ".retired-*"} {
+		if leftovers, _ := filepath.Glob(glob); len(leftovers) != 0 {
+			t.Errorf("leftover directory: %v", leftovers)
+		}
+	}
+	if got := config.DefaultConfig.TemplatesDirectory; got != dir {
+		t.Errorf("in-memory template dir = %q, want %q", got, dir)
+	}
+	configPath := filepath.Join(config.DefaultConfig.GetConfigDir(), ".templates-config.json")
+	raw, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("read %s: %v", configPath, readErr)
+	}
+	if strings.Contains(string(raw), ".incoming-") || strings.Contains(string(raw), ".retired-") {
+		t.Errorf("%s still points at a temporary directory: %s", configPath, raw)
+	}
+	if !strings.Contains(string(raw), dir) {
+		t.Errorf("%s lost the live template path %q: %s", configPath, dir, raw)
+	}
+}
+
+func countYAML(t *testing.T, dir string) int {
+	t.Helper()
+	count := 0
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".yaml") {
+			count++
+		}
+		return nil
+	})
+	return count
 }

--- a/pkg/runtools/templates_test.go
+++ b/pkg/runtools/templates_test.go
@@ -70,36 +70,6 @@ func writeTemplate(t *testing.T, dir, rel string) {
 	}
 }
 
-func TestMissingTemplates(t *testing.T) {
-	dir := stubTemplates(t, "v10.4.8")
-	writeTemplate(t, dir, "http/cves/2026/CVE-2026-1.yaml")
-
-	absent := filepath.Join(t.TempDir(), "private", "priv.yaml")
-	writeTemplate(t, filepath.Dir(absent), "priv.yaml")
-
-	required := []string{
-		"http/cves/2026/CVE-2026-1.yaml", // present
-		"http/cves/2026/CVE-2026-2.yaml", // missing
-		"http/cves/2025/CVE-2025-9.yaml", // missing
-		absent,                           // absolute: private template, not ours to verify
-		"",                               // ignored
-	}
-
-	got := MissingTemplates(required)
-	want := []string{"http/cves/2026/CVE-2026-2.yaml", "http/cves/2025/CVE-2025-9.yaml"}
-	if strings.Join(got, ",") != strings.Join(want, ",") {
-		t.Errorf("MissingTemplates() = %v, want %v", got, want)
-	}
-}
-
-// A private template living outside the public dir must never trigger a repair.
-func TestMissingTemplatesIgnoresAbsolutePaths(t *testing.T) {
-	stubTemplates(t, "v10.4.8")
-	if got := MissingTemplates([]string{"/tmp/pd-agent-priv-x/my-check.yaml"}); got != nil {
-		t.Errorf("MissingTemplates() = %v, want nil for absolute paths", got)
-	}
-}
-
 func TestLatestTemplateTagCaches(t *testing.T) {
 	stubTemplates(t, "v10.4.5")
 
@@ -779,5 +749,69 @@ func TestRepairWaitsForAnInFlightTemplateLoad(t *testing.T) {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		t.Fatal("repair never completed after the load finished")
+	}
+}
+
+// Resolution must match what the scan will actually do, so it defers to nuclei's
+// resolver instead of stat'ing paths.
+func TestMissingTemplatesUsesNucleiResolver(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/cves/2024/CVE-2024-1.yaml")
+	writeTemplate(t, dir, "http/cves/2024/CVE-2024-2.yaml")
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool // reported missing
+	}{
+		{name: "literal present", input: "http/cves/2024/CVE-2024-1.yaml", want: false},
+		{name: "literal absent", input: "http/cves/2024/CVE-2024-9.yaml", want: true},
+		// Regression: the stat loop called this missing, hard-failing the chunk
+		// and queueing a reinstall, while nuclei expands it to two templates.
+		{name: "glob that matches", input: "http/cves/2024/*.yaml", want: false},
+		{name: "glob with no match", input: "http/cves/2099/*.yaml", want: true},
+		{name: "directory", input: "http/cves/2024", want: false},
+		{name: "extensionless", input: "http/cves/2024/CVE-2024-1", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := len(MissingTemplates([]string{tt.input})) > 0
+			if got != tt.want {
+				t.Errorf("MissingTemplates(%q) missing = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMissingTemplatesPreservesInputOrderAndDedupes(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/present.yaml")
+
+	got := MissingTemplates([]string{"b.yaml", "http/present.yaml", "a.yaml", "b.yaml"})
+	if strings.Join(got, ",") != "b.yaml,a.yaml" {
+		t.Errorf("MissingTemplates() = %v, want [b.yaml a.yaml]", got)
+	}
+}
+
+// Reinstalling the public set cannot produce a private template, so an absent
+// one must not queue a repair even though it is reported.
+func TestAnyPublic(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  bool
+	}{
+		{name: "relative", input: []string{"http/x.yaml"}, want: true},
+		{name: "absolute only", input: []string{"/tmp/pd-agent-priv-x/my-check.yaml"}, want: false},
+		{name: "mixed", input: []string{"/tmp/priv/a.yaml", "http/x.yaml"}, want: true},
+		{name: "empty", input: nil, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AnyPublic(tt.input); got != tt.want {
+				t.Errorf("AnyPublic(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/runtools/templates_test.go
+++ b/pkg/runtools/templates_test.go
@@ -30,7 +30,7 @@ func stubTemplates(t *testing.T, version string) string {
 	prevDir := config.DefaultConfig.TemplatesDirectory
 	prevVersion := config.DefaultConfig.TemplateVersion
 	prevLatest := config.DefaultConfig.LatestNucleiTemplatesVersion
-	prevFetch, prevUpdate, prevFresh, prevNow := fetchLatestTag, incrementalUpdate, freshInstall, nowFn
+	prevFetch, prevFresh, prevNow := fetchLatestTag, freshInstall, nowFn
 	prevWrite := writeTemplatesConfig
 	writeTemplatesConfig = func() error { return nil }
 
@@ -42,7 +42,7 @@ func stubTemplates(t *testing.T, version string) string {
 		config.DefaultConfig.TemplatesDirectory = prevDir
 		config.DefaultConfig.TemplateVersion = prevVersion
 		config.DefaultConfig.LatestNucleiTemplatesVersion = prevLatest
-		fetchLatestTag, incrementalUpdate, freshInstall, nowFn = prevFetch, prevUpdate, prevFresh, prevNow
+		fetchLatestTag, freshInstall, nowFn = prevFetch, prevFresh, prevNow
 		writeTemplatesConfig = prevWrite
 		resetLatestTagCache()
 	})
@@ -307,19 +307,20 @@ func TestEnsureLatestTemplatesUpdatesWhenBehind(t *testing.T) {
 
 	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
 	updated := false
-	incrementalUpdate = func() error {
+	installStub(t)
+	download := freshInstall
+	freshInstall = func() error {
 		updated = true
 		config.DefaultConfig.TemplateVersion = "v10.4.8"
-		return nil
+		return download()
 	}
-	freshInstall = func() error { t.Fatal("reinstall must not run when the update succeeds"); return nil }
 
 	from, to, err := EnsureLatestTemplates(context.Background())
 	if err != nil {
 		t.Fatalf("EnsureLatestTemplates: %v", err)
 	}
 	if !updated {
-		t.Error("incremental update never ran despite being 3 releases behind")
+		t.Error("no install ran despite being 3 releases behind")
 	}
 	if from != "v10.4.5" || to != "v10.4.8" {
 		t.Errorf("versions = %s -> %s, want v10.4.5 -> v10.4.8", from, to)
@@ -329,8 +330,7 @@ func TestEnsureLatestTemplatesUpdatesWhenBehind(t *testing.T) {
 func TestEnsureLatestTemplatesNoopWhenCurrent(t *testing.T) {
 	stubTemplates(t, "v10.4.8")
 	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
-	incrementalUpdate = func() error { t.Fatal("update must not run when already current"); return nil }
-	freshInstall = func() error { t.Fatal("reinstall must not run when already current"); return nil }
+	freshInstall = func() error { t.Fatal("nothing must install when already current"); return nil }
 
 	from, to, err := EnsureLatestTemplates(context.Background())
 	if err != nil {
@@ -341,26 +341,22 @@ func TestEnsureLatestTemplatesNoopWhenCurrent(t *testing.T) {
 	}
 }
 
-// An update that reports success but leaves the version behind is a lie; fall
-// back to a full reinstall rather than trusting it.
-func TestEnsureLatestTemplatesReinstallsWhenUpdateDoesNotLand(t *testing.T) {
+// An install that reports success but leaves the version behind is a lie, and
+// must not be reported as an upgrade.
+func TestEnsureLatestTemplatesFailsWhenInstallDoesNotLandTheVersion(t *testing.T) {
 	stubTemplates(t, "v10.4.5")
 	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
-	incrementalUpdate = func() error { return nil } // claims success, changes nothing
-	reinstalled := false
-	installStub(t)
-	download := freshInstall
-	freshInstall = func() error {
-		reinstalled = true
-		config.DefaultConfig.TemplateVersion = "v10.4.8"
-		return download()
-	}
+	installStub(t) // writes templates but never sets the version
 
-	if _, to, err := EnsureLatestTemplates(context.Background()); err != nil || to != "v10.4.8" {
-		t.Fatalf("EnsureLatestTemplates = %q, %v; want v10.4.8, nil", to, err)
+	from, to, err := EnsureLatestTemplates(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the install did not reach the newest release")
 	}
-	if !reinstalled {
-		t.Error("expected a reinstall when the update did not land")
+	if !strings.Contains(err.Error(), "v10.4.8") {
+		t.Errorf("err = %v, want it to name the wanted release", err)
+	}
+	if from != "v10.4.5" || to != "v10.4.5" {
+		t.Errorf("versions = %s -> %s, want both at v10.4.5", from, to)
 	}
 }
 
@@ -374,10 +370,12 @@ func TestEnsureLatestTemplatesInstallsWhenDirMissing(t *testing.T) {
 		return "", nil
 	}
 	installed := false
+	installStub(t)
+	download := freshInstall
 	freshInstall = func() error {
 		installed = true
 		config.DefaultConfig.TemplateVersion = "v10.4.8"
-		return os.MkdirAll(dir, 0o755)
+		return download()
 	}
 
 	if _, to, err := EnsureLatestTemplates(context.Background()); err != nil || to != "v10.4.8" {
@@ -386,13 +384,15 @@ func TestEnsureLatestTemplatesInstallsWhenDirMissing(t *testing.T) {
 	if !installed {
 		t.Error("expected a fresh install for a missing template dir")
 	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("template dir absent after the install: %v", err)
+	}
 }
 
 func TestEnsureLatestTemplatesPropagatesTagFailure(t *testing.T) {
 	stubTemplates(t, "v10.4.5")
 	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
-	incrementalUpdate = func() error { t.Fatal("must not update blind"); return nil }
-	freshInstall = func() error { t.Fatal("must not reinstall blind"); return nil }
+	freshInstall = func() error { t.Fatal("must not install blind"); return nil }
 
 	from, _, err := EnsureLatestTemplates(context.Background())
 	if err == nil {
@@ -477,11 +477,12 @@ func TestEnsureLatestTemplatesFallsBackToLastKnownTag(t *testing.T) {
 
 	nowFn = func() time.Time { return base.Add(latestTagTTL + latestTagFailTTL + time.Second) }
 	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
-	incrementalUpdate = func() error {
+	installStub(t)
+	download := freshInstall
+	freshInstall = func() error {
 		config.DefaultConfig.TemplateVersion = "v10.4.8"
-		return nil
+		return download()
 	}
-	freshInstall = func() error { t.Fatal("must not reinstall when the incremental update works"); return nil }
 
 	from, to, err := EnsureLatestTemplates(context.Background())
 	if err != nil {
@@ -496,8 +497,7 @@ func TestEnsureLatestTemplatesFallsBackToLastKnownTag(t *testing.T) {
 func TestEnsureLatestTemplatesFailsWithoutAnyKnownTag(t *testing.T) {
 	stubTemplates(t, "v10.4.5")
 	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
-	incrementalUpdate = func() error { t.Fatal("must not update blind"); return nil }
-	freshInstall = func() error { t.Fatal("must not reinstall blind"); return nil }
+	freshInstall = func() error { t.Fatal("must not install blind"); return nil }
 
 	if _, _, err := EnsureLatestTemplates(context.Background()); !errors.Is(err, ErrFreshnessUnknown) {
 		t.Fatalf("err = %v, want ErrFreshnessUnknown", err)
@@ -548,7 +548,6 @@ func TestVerifyTemplatesForNeverInstalls(t *testing.T) {
 	dir := stubTemplates(t, "v10.4.8")
 	writeTemplate(t, dir, "http/present.yaml")
 	freshInstall = func() error { t.Fatal("chunk-scope verification must never install"); return nil }
-	incrementalUpdate = func() error { t.Fatal("chunk-scope verification must never update"); return nil }
 
 	if got := VerifyTemplatesFor([]string{"http/present.yaml"}); got != nil {
 		t.Errorf("VerifyTemplatesFor() = %v, want nil", got)
@@ -776,9 +775,9 @@ func TestMissingTemplatesUsesNucleiResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := len(MissingTemplates([]string{tt.input})) > 0
+			got := len(missingTemplates([]string{tt.input})) > 0
 			if got != tt.want {
-				t.Errorf("MissingTemplates(%q) missing = %v, want %v", tt.input, got, tt.want)
+				t.Errorf("missingTemplates(%q) missing = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -788,9 +787,9 @@ func TestMissingTemplatesPreservesInputOrderAndDedupes(t *testing.T) {
 	dir := stubTemplates(t, "v10.4.8")
 	writeTemplate(t, dir, "http/present.yaml")
 
-	got := MissingTemplates([]string{"b.yaml", "http/present.yaml", "a.yaml", "b.yaml"})
+	got := missingTemplates([]string{"b.yaml", "http/present.yaml", "a.yaml", "b.yaml"})
 	if strings.Join(got, ",") != "b.yaml,a.yaml" {
-		t.Errorf("MissingTemplates() = %v, want [b.yaml a.yaml]", got)
+		t.Errorf("missingTemplates() = %v, want [b.yaml a.yaml]", got)
 	}
 }
 
@@ -813,5 +812,59 @@ func TestAnyPublic(t *testing.T) {
 				t.Errorf("AnyPublic(%v) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// blockedByWriteLock reports whether fn waits while a staged install holds the
+// write lock. An unlocked reader sees the repointed global mid-download and
+// concludes every template is missing.
+func blockedByWriteLock(t *testing.T, fn func()) bool {
+	t.Helper()
+
+	templateRW.Lock()
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	blocked := false
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		blocked = true
+	}
+	templateRW.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("call never completed after the write lock was released")
+	}
+	return blocked
+}
+
+func TestVerifyTemplatesForTakesTheReadLock(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/present.yaml")
+
+	var missing []string
+	if !blockedByWriteLock(t, func() { missing = VerifyTemplatesFor([]string{"http/present.yaml"}) }) {
+		t.Error("VerifyTemplatesFor read the template dir during a staged install")
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want none once the install finished", missing)
+	}
+}
+
+func TestTemplateDirTakesTheReadLock(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+
+	var got string
+	if !blockedByWriteLock(t, func() { got = TemplateDir() }) {
+		t.Error("TemplateDir read the global during a staged install")
+	}
+	if got != dir {
+		t.Errorf("TemplateDir() = %q, want %q", got, dir)
 	}
 }

--- a/pkg/runtools/templates_test.go
+++ b/pkg/runtools/templates_test.go
@@ -1,0 +1,369 @@
+package runtools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+)
+
+// stubTemplates points nuclei's config at a temp dir and swaps the network and
+// installer hooks, then restores everything on cleanup.
+func stubTemplates(t *testing.T, version string) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "nuclei-templates")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir template dir: %v", err)
+	}
+
+	prevDir := config.DefaultConfig.TemplatesDirectory
+	prevVersion := config.DefaultConfig.TemplateVersion
+	prevLatest := config.DefaultConfig.LatestNucleiTemplatesVersion
+	prevFetch, prevUpdate, prevFresh, prevNow := fetchLatestTag, incrementalUpdate, freshInstall, nowFn
+
+	config.DefaultConfig.TemplatesDirectory = dir
+	config.DefaultConfig.TemplateVersion = version
+	resetLatestTagCache()
+
+	t.Cleanup(func() {
+		config.DefaultConfig.TemplatesDirectory = prevDir
+		config.DefaultConfig.TemplateVersion = prevVersion
+		config.DefaultConfig.LatestNucleiTemplatesVersion = prevLatest
+		fetchLatestTag, incrementalUpdate, freshInstall, nowFn = prevFetch, prevUpdate, prevFresh, prevNow
+		resetLatestTagCache()
+	})
+
+	return dir
+}
+
+func resetLatestTagCache() {
+	latestTagMu.Lock()
+	defer latestTagMu.Unlock()
+	latestTag, latestTagAt = "", time.Time{}
+}
+
+func writeTemplate(t *testing.T, dir, rel string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte("id: test\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+}
+
+func TestMissingTemplates(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/cves/2026/CVE-2026-1.yaml")
+
+	absent := filepath.Join(t.TempDir(), "private", "priv.yaml")
+	writeTemplate(t, filepath.Dir(absent), "priv.yaml")
+
+	required := []string{
+		"http/cves/2026/CVE-2026-1.yaml", // present
+		"http/cves/2026/CVE-2026-2.yaml", // missing
+		"http/cves/2025/CVE-2025-9.yaml", // missing
+		absent,                           // absolute: private template, not ours to verify
+		"",                               // ignored
+	}
+
+	got := MissingTemplates(required)
+	want := []string{"http/cves/2026/CVE-2026-2.yaml", "http/cves/2025/CVE-2025-9.yaml"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("MissingTemplates() = %v, want %v", got, want)
+	}
+}
+
+// A private template living outside the public dir must never trigger a repair.
+func TestMissingTemplatesIgnoresAbsolutePaths(t *testing.T) {
+	stubTemplates(t, "v10.4.8")
+	if got := MissingTemplates([]string{"/tmp/pd-agent-priv-x/my-check.yaml"}); got != nil {
+		t.Errorf("MissingTemplates() = %v, want nil for absolute paths", got)
+	}
+}
+
+func TestLatestTemplateTagCaches(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+
+	calls := 0
+	fetchLatestTag = func(context.Context) (string, error) {
+		calls++
+		return "v10.4.8", nil
+	}
+	base := time.Now()
+	nowFn = func() time.Time { return base }
+
+	for range 3 {
+		tag, err := LatestTemplateTag(context.Background())
+		if err != nil {
+			t.Fatalf("LatestTemplateTag: %v", err)
+		}
+		if tag != "v10.4.8" {
+			t.Fatalf("tag = %q, want v10.4.8", tag)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("fetches = %d, want 1 within the TTL", calls)
+	}
+
+	nowFn = func() time.Time { return base.Add(latestTagTTL + time.Second) }
+	if _, err := LatestTemplateTag(context.Background()); err != nil {
+		t.Fatalf("LatestTemplateTag after TTL: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("fetches = %d, want 2 after the TTL expires", calls)
+	}
+}
+
+func TestLatestTemplateTagError(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("no network") }
+
+	if _, err := LatestTemplateTag(context.Background()); err == nil {
+		t.Fatal("expected an error when the release API is unreachable")
+	}
+}
+
+func TestFetchLatestTagFromGitHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v10.4.8"})
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var release struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if release.TagName != "v10.4.8" {
+		t.Errorf("tag_name = %q, want v10.4.8", release.TagName)
+	}
+}
+
+// The bug this whole change exists for: installed version behind the newest
+// release must trigger an update, no matter what nuclei cached.
+func TestEnsureLatestTemplatesUpdatesWhenBehind(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+	// Nuclei's stale cache claiming we are current must not be believed.
+	config.DefaultConfig.LatestNucleiTemplatesVersion = "v10.4.5"
+
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	updated := false
+	incrementalUpdate = func() error {
+		updated = true
+		config.DefaultConfig.TemplateVersion = "v10.4.8"
+		return nil
+	}
+	freshInstall = func() error { t.Fatal("reinstall must not run when the update succeeds"); return nil }
+
+	from, to, err := EnsureLatestTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureLatestTemplates: %v", err)
+	}
+	if !updated {
+		t.Error("incremental update never ran despite being 3 releases behind")
+	}
+	if from != "v10.4.5" || to != "v10.4.8" {
+		t.Errorf("versions = %s -> %s, want v10.4.5 -> v10.4.8", from, to)
+	}
+}
+
+func TestEnsureLatestTemplatesNoopWhenCurrent(t *testing.T) {
+	stubTemplates(t, "v10.4.8")
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	incrementalUpdate = func() error { t.Fatal("update must not run when already current"); return nil }
+	freshInstall = func() error { t.Fatal("reinstall must not run when already current"); return nil }
+
+	from, to, err := EnsureLatestTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureLatestTemplates: %v", err)
+	}
+	if from != to || to != "v10.4.8" {
+		t.Errorf("versions = %s -> %s, want no change at v10.4.8", from, to)
+	}
+}
+
+// An update that reports success but leaves the version behind is a lie; fall
+// back to a full reinstall rather than trusting it.
+func TestEnsureLatestTemplatesReinstallsWhenUpdateDoesNotLand(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	incrementalUpdate = func() error { return nil } // claims success, changes nothing
+	reinstalled := false
+	freshInstall = func() error {
+		reinstalled = true
+		config.DefaultConfig.TemplateVersion = "v10.4.8"
+		return nil
+	}
+
+	if _, to, err := EnsureLatestTemplates(context.Background()); err != nil || to != "v10.4.8" {
+		t.Fatalf("EnsureLatestTemplates = %q, %v; want v10.4.8, nil", to, err)
+	}
+	if !reinstalled {
+		t.Error("expected a reinstall when the update did not land")
+	}
+}
+
+func TestEnsureLatestTemplatesInstallsWhenDirMissing(t *testing.T) {
+	dir := stubTemplates(t, "")
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+	fetchLatestTag = func(context.Context) (string, error) {
+		t.Fatal("must not need the release API to install a missing dir")
+		return "", nil
+	}
+	installed := false
+	freshInstall = func() error {
+		installed = true
+		config.DefaultConfig.TemplateVersion = "v10.4.8"
+		return os.MkdirAll(dir, 0o755)
+	}
+
+	if _, to, err := EnsureLatestTemplates(context.Background()); err != nil || to != "v10.4.8" {
+		t.Fatalf("EnsureLatestTemplates = %q, %v; want v10.4.8, nil", to, err)
+	}
+	if !installed {
+		t.Error("expected a fresh install for a missing template dir")
+	}
+}
+
+func TestEnsureLatestTemplatesPropagatesTagFailure(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
+	incrementalUpdate = func() error { t.Fatal("must not update blind"); return nil }
+	freshInstall = func() error { t.Fatal("must not reinstall blind"); return nil }
+
+	if _, _, err := EnsureLatestTemplates(context.Background()); err == nil {
+		t.Fatal("expected the release-API failure to surface")
+	}
+}
+
+// The case that produced the bad scan: version current, files absent.
+func TestEnsureTemplatesForRepairsMissingFiles(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	required := []string{"http/cves/2026/CVE-2026-49049.yaml", "http/cves/2025/CVE-2025-54988.yaml"}
+
+	freshInstall = func() error {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		for _, rel := range required {
+			full := filepath.Join(dir, rel)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(full, []byte("id: x\n"), 0o600); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	missing, err := EnsureTemplatesFor(context.Background(), required)
+	if err != nil {
+		t.Fatalf("EnsureTemplatesFor: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing after repair = %v, want none", missing)
+	}
+	for _, rel := range required {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("%s still absent after repair", rel)
+		}
+	}
+}
+
+func TestEnsureTemplatesForSkipsRepairWhenComplete(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/cves/2026/CVE-2026-1.yaml")
+
+	freshInstall = func() error { t.Fatal("must not reinstall when every template is present"); return nil }
+
+	missing, err := EnsureTemplatesFor(context.Background(), []string{"http/cves/2026/CVE-2026-1.yaml"})
+	if err != nil || len(missing) != 0 {
+		t.Fatalf("EnsureTemplatesFor = %v, %v; want none, nil", missing, err)
+	}
+}
+
+// A template the release genuinely does not carry must be reported, not hidden.
+func TestEnsureTemplatesForReportsStillMissing(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	freshInstall = func() error { return os.MkdirAll(dir, 0o755) }
+
+	missing, err := EnsureTemplatesFor(context.Background(), []string{"http/cves/2099/CVE-2099-1.yaml"})
+	if err == nil {
+		t.Fatal("expected an error when templates are absent after a reinstall")
+	}
+	if len(missing) != 1 || missing[0] != "http/cves/2099/CVE-2099-1.yaml" {
+		t.Errorf("missing = %v, want the one absent path", missing)
+	}
+}
+
+func TestReinstallTemplatesRestoresOnFailure(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.5")
+	writeTemplate(t, dir, "http/keep-me.yaml")
+
+	freshInstall = func() error { return errors.New("download failed") }
+
+	if err := ReinstallTemplates(context.Background()); err == nil {
+		t.Fatal("expected the download failure to surface")
+	}
+	// A failed repair must not leave the agent with zero templates.
+	if _, err := os.Stat(filepath.Join(dir, "http/keep-me.yaml")); err != nil {
+		t.Errorf("existing templates were lost on a failed reinstall: %v", err)
+	}
+	entries, _ := filepath.Glob(dir + ".stale-*")
+	if len(entries) != 0 {
+		t.Errorf("stale dir left behind: %v", entries)
+	}
+}
+
+func TestSafeToReplace(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr bool
+	}{
+		{name: "normal path", dir: filepath.Join(home, "nuclei-templates")},
+		{name: "empty", dir: "", wantErr: true},
+		{name: "relative", dir: "nuclei-templates", wantErr: true},
+		{name: "root", dir: string(filepath.Separator), wantErr: true},
+		{name: "home itself", dir: home, wantErr: true},
+		{name: "top level", dir: string(filepath.Separator) + "templates", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := safeToReplace(tt.dir); (err != nil) != tt.wantErr {
+				t.Errorf("safeToReplace(%q) error = %v, wantErr %v", tt.dir, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/runtools/templates_test.go
+++ b/pkg/runtools/templates_test.go
@@ -8,11 +8,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/projectdiscovery/nuclei/v3/pkg/catalog/config"
+	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
 )
 
 // stubTemplates points nuclei's config at a temp dir and swaps the network and
@@ -48,7 +50,7 @@ func stubTemplates(t *testing.T, version string) string {
 func resetLatestTagCache() {
 	latestTagMu.Lock()
 	defer latestTagMu.Unlock()
-	latestTag, latestTagAt = "", time.Time{}
+	latestTag, latestTagAt, latestTagTry, latestTagErr = "", time.Time{}, time.Time{}, nil
 }
 
 func writeTemplate(t *testing.T, dir, rel string) {
@@ -129,35 +131,194 @@ func TestLatestTemplateTagError(t *testing.T) {
 	stubTemplates(t, "v10.4.5")
 	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("no network") }
 
-	if _, err := LatestTemplateTag(context.Background()); err == nil {
+	_, err := LatestTemplateTag(context.Background())
+	if err == nil {
 		t.Fatal("expected an error when the release API is unreachable")
+	}
+	if !errors.Is(err, ErrFreshnessUnknown) {
+		t.Errorf("err = %v, want it to wrap ErrFreshnessUnknown", err)
+	}
+}
+
+// Without caching failures a rate-limited fleet retries on every scan and keeps
+// its own quota exhausted.
+func TestLatestTemplateTagCachesFailures(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+
+	calls := 0
+	fetchLatestTag = func(context.Context) (string, error) {
+		calls++
+		return "", errors.New("api down")
+	}
+	base := time.Now()
+	nowFn = func() time.Time { return base }
+
+	for range 3 {
+		if _, err := LatestTemplateTag(context.Background()); err == nil {
+			t.Fatal("expected the failure to surface")
+		}
+	}
+	if calls != 1 {
+		t.Errorf("fetches = %d, want 1 within the failure TTL", calls)
+	}
+
+	nowFn = func() time.Time { return base.Add(latestTagFailTTL + time.Second) }
+	if _, err := LatestTemplateTag(context.Background()); err == nil {
+		t.Fatal("expected the failure to surface after the TTL")
+	}
+	if calls != 2 {
+		t.Errorf("fetches = %d, want 2 after the failure TTL expires", calls)
+	}
+}
+
+// A transient outage must not pin the agent to the cached failure.
+func TestLatestTemplateTagRecoversAfterFailure(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+
+	fail := true
+	fetchLatestTag = func(context.Context) (string, error) {
+		if fail {
+			return "", errors.New("api down")
+		}
+		return "v10.4.8", nil
+	}
+	base := time.Now()
+	nowFn = func() time.Time { return base }
+
+	if _, err := LatestTemplateTag(context.Background()); err == nil {
+		t.Fatal("expected the first lookup to fail")
+	}
+
+	fail = false
+	nowFn = func() time.Time { return base.Add(latestTagFailTTL + time.Second) }
+	tag, err := LatestTemplateTag(context.Background())
+	if err != nil {
+		t.Fatalf("LatestTemplateTag after recovery: %v", err)
+	}
+	if tag != "v10.4.8" {
+		t.Errorf("tag = %q, want v10.4.8", tag)
+	}
+}
+
+// stubLatestURL points the release lookup at a test server for one test.
+func stubLatestURL(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	prev := templatesLatestURL
+	templatesLatestURL = srv.URL
+	t.Cleanup(func() {
+		templatesLatestURL = prev
+		srv.Close()
+	})
+}
+
+func serveTag(tag string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": tag})
 	}
 }
 
 func TestFetchLatestTagFromGitHub(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v10.4.8"})
-	}))
-	defer srv.Close()
+	t.Setenv(envconfig.KeyGitHubToken, "")
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("do: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	var gotAuth string
+	stubLatestURL(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		serveTag("v10.4.8")(w, r)
+	})
 
-	var release struct {
-		TagName string `json:"tag_name"`
+	tag, err := fetchLatestTagFromGitHub(context.Background())
+	if err != nil {
+		t.Fatalf("fetchLatestTagFromGitHub: %v", err)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		t.Fatalf("decode: %v", err)
+	if tag != "v10.4.8" {
+		t.Errorf("tag = %q, want v10.4.8", tag)
 	}
-	if release.TagName != "v10.4.8" {
-		t.Errorf("tag_name = %q, want v10.4.8", release.TagName)
+	if gotAuth != "" {
+		t.Errorf("Authorization = %q, want none when no token is set", gotAuth)
+	}
+}
+
+// The lookup must spend the same token the downloads already use, or an
+// authenticated agent still burns the 60/hr unauthenticated per-IP budget.
+func TestFetchLatestTagFromGitHubSendsToken(t *testing.T) {
+	t.Setenv(envconfig.KeyGitHubToken, "ghp_example")
+
+	var gotAuth string
+	stubLatestURL(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		serveTag("v10.4.8")(w, r)
+	})
+
+	if _, err := fetchLatestTagFromGitHub(context.Background()); err != nil {
+		t.Fatalf("fetchLatestTagFromGitHub: %v", err)
+	}
+	if gotAuth != "Bearer ghp_example" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer ghp_example")
+	}
+}
+
+// The lookup gates agent startup, so it must never run on a client that can
+// hang forever. http.DefaultClient has no timeout.
+func TestLatestTagClientHasTimeout(t *testing.T) {
+	if latestTagClient.Timeout == 0 {
+		t.Fatal("latestTagClient has no timeout; a stalled connection would hang boot")
+	}
+}
+
+func rateLimitedHandler(reset time.Time) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+		w.WriteHeader(http.StatusForbidden)
+	}
+}
+
+func TestFetchLatestTagFromGitHubRateLimited(t *testing.T) {
+	t.Setenv(envconfig.KeyGitHubToken, "")
+	stubLatestURL(t, rateLimitedHandler(time.Now().Add(20*time.Minute)))
+
+	_, err := fetchLatestTagFromGitHub(context.Background())
+	if !errors.Is(err, ErrGitHubRateLimited) {
+		t.Fatalf("err = %v, want ErrGitHubRateLimited", err)
+	}
+	if !strings.Contains(err.Error(), envconfig.KeyGitHubToken) {
+		t.Errorf("err = %q, want it to name %s as the fix", err, envconfig.KeyGitHubToken)
+	}
+	if !strings.Contains(err.Error(), "resets in") {
+		t.Errorf("err = %q, want the reset window", err)
+	}
+}
+
+// With a token already set, telling the operator to set one is useless advice.
+func TestFetchLatestTagFromGitHubRateLimitedWithToken(t *testing.T) {
+	t.Setenv(envconfig.KeyGitHubToken, "ghp_example")
+	stubLatestURL(t, rateLimitedHandler(time.Now().Add(20*time.Minute)))
+
+	_, err := fetchLatestTagFromGitHub(context.Background())
+	if !errors.Is(err, ErrGitHubRateLimited) {
+		t.Fatalf("err = %v, want ErrGitHubRateLimited", err)
+	}
+	if !strings.Contains(err.Error(), "also exhausted") {
+		t.Errorf("err = %q, want it to say the configured token is exhausted", err)
+	}
+}
+
+// A bad token also answers 403; only quota exhaustion sets Remaining: 0, and
+// the two need opposite advice.
+func TestFetchLatestTagFromGitHubForbiddenIsNotRateLimit(t *testing.T) {
+	t.Setenv(envconfig.KeyGitHubToken, "ghp_bad")
+	stubLatestURL(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "59")
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	_, err := fetchLatestTagFromGitHub(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for 403")
+	}
+	if errors.Is(err, ErrGitHubRateLimited) {
+		t.Errorf("err = %v, want a plain status error, not a rate-limit diagnosis", err)
 	}
 }
 
@@ -255,8 +416,17 @@ func TestEnsureLatestTemplatesPropagatesTagFailure(t *testing.T) {
 	incrementalUpdate = func() error { t.Fatal("must not update blind"); return nil }
 	freshInstall = func() error { t.Fatal("must not reinstall blind"); return nil }
 
-	if _, _, err := EnsureLatestTemplates(context.Background()); err == nil {
+	from, _, err := EnsureLatestTemplates(context.Background())
+	if err == nil {
 		t.Fatal("expected the release-API failure to surface")
+	}
+	// ensureNucleiTemplates keys off both of these to warn-and-continue rather
+	// than ground an agent whose templates are already on disk.
+	if !errors.Is(err, ErrFreshnessUnknown) {
+		t.Errorf("err = %v, want it to wrap ErrFreshnessUnknown", err)
+	}
+	if from != "v10.4.5" {
+		t.Errorf("from = %q, want the installed version so the caller can tell templates exist", from)
 	}
 }
 
@@ -327,7 +497,7 @@ func TestReinstallTemplatesRestoresOnFailure(t *testing.T) {
 
 	freshInstall = func() error { return errors.New("download failed") }
 
-	if err := ReinstallTemplates(context.Background()); err == nil {
+	if err := reinstallTemplates(); err == nil {
 		t.Fatal("expected the download failure to surface")
 	}
 	// A failed repair must not leave the agent with zero templates.
@@ -365,5 +535,91 @@ func TestSafeToReplace(t *testing.T) {
 				t.Errorf("safeToReplace(%q) error = %v, wantErr %v", tt.dir, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// A tag resolved minutes ago still beats no comparison at all, so an outage
+// must not throw it away.
+func TestLatestTemplateTagKeepsLastKnownTagOnFailure(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+
+	base := time.Now()
+	nowFn = func() time.Time { return base }
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	if _, err := LatestTemplateTag(context.Background()); err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+
+	nowFn = func() time.Time { return base.Add(latestTagTTL + time.Second) }
+	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
+	if _, err := LatestTemplateTag(context.Background()); err == nil {
+		t.Fatal("expected the failure to surface rather than a stale tag posing as fresh")
+	}
+
+	tag, at := LastKnownTemplateTag()
+	if tag != "v10.4.8" {
+		t.Errorf("LastKnownTemplateTag() = %q, want the retained v10.4.8", tag)
+	}
+	if !at.Equal(base) {
+		t.Errorf("resolved-at = %v, want the original success time %v", at, base)
+	}
+}
+
+// With the release API down, an agent must still update toward the last known
+// release instead of standing still.
+func TestEnsureLatestTemplatesFallsBackToLastKnownTag(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+
+	base := time.Now()
+	nowFn = func() time.Time { return base }
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	if _, err := LatestTemplateTag(context.Background()); err != nil {
+		t.Fatalf("seed lookup: %v", err)
+	}
+
+	nowFn = func() time.Time { return base.Add(latestTagTTL + latestTagFailTTL + time.Second) }
+	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
+	incrementalUpdate = func() error {
+		config.DefaultConfig.TemplateVersion = "v10.4.8"
+		return nil
+	}
+	freshInstall = func() error { t.Fatal("must not reinstall when the incremental update works"); return nil }
+
+	from, to, err := EnsureLatestTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureLatestTemplates: %v", err)
+	}
+	if from != "v10.4.5" || to != "v10.4.8" {
+		t.Errorf("versions = %s -> %s, want v10.4.5 -> v10.4.8 via the last known tag", from, to)
+	}
+}
+
+// No lookup has ever succeeded, so there is nothing to fall back to.
+func TestEnsureLatestTemplatesFailsWithoutAnyKnownTag(t *testing.T) {
+	stubTemplates(t, "v10.4.5")
+	fetchLatestTag = func(context.Context) (string, error) { return "", errors.New("api down") }
+	incrementalUpdate = func() error { t.Fatal("must not update blind"); return nil }
+	freshInstall = func() error { t.Fatal("must not reinstall blind"); return nil }
+
+	if _, _, err := EnsureLatestTemplates(context.Background()); !errors.Is(err, ErrFreshnessUnknown) {
+		t.Fatalf("err = %v, want ErrFreshnessUnknown", err)
+	}
+}
+
+// Secondary rate limits answer with Retry-After and leave X-RateLimit-Remaining
+// alone, so keying only on Remaining misses them.
+func TestFetchLatestTagFromGitHubSecondaryRateLimit(t *testing.T) {
+	t.Setenv(envconfig.KeyGitHubToken, "")
+	stubLatestURL(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := fetchLatestTagFromGitHub(context.Background())
+	if !errors.Is(err, ErrGitHubRateLimited) {
+		t.Fatalf("err = %v, want ErrGitHubRateLimited", err)
+	}
+	if !strings.Contains(err.Error(), "retry after 60s") {
+		t.Errorf("err = %q, want the Retry-After window", err)
 	}
 }

--- a/pkg/runtools/templates_test.go
+++ b/pkg/runtools/templates_test.go
@@ -31,6 +31,8 @@ func stubTemplates(t *testing.T, version string) string {
 	prevVersion := config.DefaultConfig.TemplateVersion
 	prevLatest := config.DefaultConfig.LatestNucleiTemplatesVersion
 	prevFetch, prevUpdate, prevFresh, prevNow := fetchLatestTag, incrementalUpdate, freshInstall, nowFn
+	prevWrite := writeTemplatesConfig
+	writeTemplatesConfig = func() error { return nil }
 
 	config.DefaultConfig.TemplatesDirectory = dir
 	config.DefaultConfig.TemplateVersion = version
@@ -41,6 +43,7 @@ func stubTemplates(t *testing.T, version string) string {
 		config.DefaultConfig.TemplateVersion = prevVersion
 		config.DefaultConfig.LatestNucleiTemplatesVersion = prevLatest
 		fetchLatestTag, incrementalUpdate, freshInstall, nowFn = prevFetch, prevUpdate, prevFresh, prevNow
+		writeTemplatesConfig = prevWrite
 		resetLatestTagCache()
 	})
 
@@ -51,6 +54,9 @@ func resetLatestTagCache() {
 	latestTagMu.Lock()
 	defer latestTagMu.Unlock()
 	latestTag, latestTagAt, latestTagTry, latestTagErr = "", time.Time{}, time.Time{}, nil
+	repairMu.Lock()
+	repairWanted, repairReason, repairedAtVersion = false, "", ""
+	repairMu.Unlock()
 }
 
 func writeTemplate(t *testing.T, dir, rel string) {
@@ -372,10 +378,12 @@ func TestEnsureLatestTemplatesReinstallsWhenUpdateDoesNotLand(t *testing.T) {
 	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
 	incrementalUpdate = func() error { return nil } // claims success, changes nothing
 	reinstalled := false
+	installStub(t)
+	download := freshInstall
 	freshInstall = func() error {
 		reinstalled = true
 		config.DefaultConfig.TemplateVersion = "v10.4.8"
-		return nil
+		return download()
 	}
 
 	if _, to, err := EnsureLatestTemplates(context.Background()); err != nil || to != "v10.4.8" {
@@ -427,86 +435,6 @@ func TestEnsureLatestTemplatesPropagatesTagFailure(t *testing.T) {
 	}
 	if from != "v10.4.5" {
 		t.Errorf("from = %q, want the installed version so the caller can tell templates exist", from)
-	}
-}
-
-// The case that produced the bad scan: version current, files absent.
-func TestEnsureTemplatesForRepairsMissingFiles(t *testing.T) {
-	dir := stubTemplates(t, "v10.4.8")
-	required := []string{"http/cves/2026/CVE-2026-49049.yaml", "http/cves/2025/CVE-2025-54988.yaml"}
-
-	freshInstall = func() error {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
-		}
-		for _, rel := range required {
-			full := filepath.Join(dir, rel)
-			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-				return err
-			}
-			if err := os.WriteFile(full, []byte("id: x\n"), 0o600); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	missing, err := EnsureTemplatesFor(context.Background(), required)
-	if err != nil {
-		t.Fatalf("EnsureTemplatesFor: %v", err)
-	}
-	if len(missing) != 0 {
-		t.Errorf("missing after repair = %v, want none", missing)
-	}
-	for _, rel := range required {
-		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
-			t.Errorf("%s still absent after repair", rel)
-		}
-	}
-}
-
-func TestEnsureTemplatesForSkipsRepairWhenComplete(t *testing.T) {
-	dir := stubTemplates(t, "v10.4.8")
-	writeTemplate(t, dir, "http/cves/2026/CVE-2026-1.yaml")
-
-	freshInstall = func() error { t.Fatal("must not reinstall when every template is present"); return nil }
-
-	missing, err := EnsureTemplatesFor(context.Background(), []string{"http/cves/2026/CVE-2026-1.yaml"})
-	if err != nil || len(missing) != 0 {
-		t.Fatalf("EnsureTemplatesFor = %v, %v; want none, nil", missing, err)
-	}
-}
-
-// A template the release genuinely does not carry must be reported, not hidden.
-func TestEnsureTemplatesForReportsStillMissing(t *testing.T) {
-	dir := stubTemplates(t, "v10.4.8")
-	freshInstall = func() error { return os.MkdirAll(dir, 0o755) }
-
-	missing, err := EnsureTemplatesFor(context.Background(), []string{"http/cves/2099/CVE-2099-1.yaml"})
-	if err == nil {
-		t.Fatal("expected an error when templates are absent after a reinstall")
-	}
-	if len(missing) != 1 || missing[0] != "http/cves/2099/CVE-2099-1.yaml" {
-		t.Errorf("missing = %v, want the one absent path", missing)
-	}
-}
-
-func TestReinstallTemplatesRestoresOnFailure(t *testing.T) {
-	dir := stubTemplates(t, "v10.4.5")
-	writeTemplate(t, dir, "http/keep-me.yaml")
-
-	freshInstall = func() error { return errors.New("download failed") }
-
-	if err := reinstallTemplates(); err == nil {
-		t.Fatal("expected the download failure to surface")
-	}
-	// A failed repair must not leave the agent with zero templates.
-	if _, err := os.Stat(filepath.Join(dir, "http/keep-me.yaml")); err != nil {
-		t.Errorf("existing templates were lost on a failed reinstall: %v", err)
-	}
-	entries, _ := filepath.Glob(dir + ".stale-*")
-	if len(entries) != 0 {
-		t.Errorf("stale dir left behind: %v", entries)
 	}
 }
 
@@ -621,5 +549,235 @@ func TestFetchLatestTagFromGitHubSecondaryRateLimit(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "retry after 60s") {
 		t.Errorf("err = %q, want the Retry-After window", err)
+	}
+}
+
+// installStub fills the directory nuclei is pointed at, the way a real download
+// does, and counts how many times it ran.
+func installStub(t *testing.T, rels ...string) *int {
+	t.Helper()
+	calls := 0
+	freshInstall = func() error {
+		calls++
+		dir := config.DefaultConfig.TemplatesDirectory
+		for _, rel := range append([]string{"http/seed.yaml"}, rels...) {
+			full := filepath.Join(dir, rel)
+			if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(full, []byte("id: x\n"), 0o600); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return &calls
+}
+
+func TestVerifyTemplatesForNeverInstalls(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/present.yaml")
+	freshInstall = func() error { t.Fatal("chunk-scope verification must never install"); return nil }
+	incrementalUpdate = func() error { t.Fatal("chunk-scope verification must never update"); return nil }
+
+	if got := VerifyTemplatesFor([]string{"http/present.yaml"}); got != nil {
+		t.Errorf("VerifyTemplatesFor() = %v, want nil", got)
+	}
+	if got := VerifyTemplatesFor([]string{"http/absent.yaml"}); len(got) != 1 {
+		t.Errorf("VerifyTemplatesFor() = %v, want the one missing path", got)
+	}
+}
+
+// The regression the per-chunk installer caused: N chunks, N full reinstalls.
+func TestChunkVerificationDoesNotAmplifyInstalls(t *testing.T) {
+	stubTemplates(t, "v10.4.8")
+	calls := installStub(t)
+
+	for range 8 {
+		missing := VerifyTemplatesFor([]string{"http/cves/2099/CVE-2099-1.yaml"})
+		if len(missing) != 1 {
+			t.Fatalf("missing = %v, want one", missing)
+		}
+		RequestTemplateRepair("test")
+	}
+	if *calls != 0 {
+		t.Errorf("installs during chunk verification = %d, want 0", *calls)
+	}
+
+	// The queued repair runs once, at scan scope.
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+	if _, _, err := EnsureLatestTemplates(context.Background()); err != nil {
+		t.Fatalf("EnsureLatestTemplates: %v", err)
+	}
+	if *calls != 1 {
+		t.Errorf("installs at scan scope = %d, want exactly 1", *calls)
+	}
+}
+
+// Reinstalling the same release cannot produce a template it does not carry, so
+// the attempt must not repeat until the release changes.
+func TestRepairIsNotRetriedAtTheSameRelease(t *testing.T) {
+	stubTemplates(t, "v10.4.8")
+	calls := installStub(t)
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+
+	RequestTemplateRepair("first")
+	if _, _, err := EnsureLatestTemplates(context.Background()); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if *calls != 1 {
+		t.Fatalf("installs = %d, want 1", *calls)
+	}
+
+	RequestTemplateRepair("second, same release")
+	if _, _, err := EnsureLatestTemplates(context.Background()); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if *calls != 1 {
+		t.Errorf("installs = %d, want the repair suppressed at the same release", *calls)
+	}
+
+	// A new release clears the suppression.
+	config.DefaultConfig.TemplateVersion = "v10.4.9"
+	RequestTemplateRepair("after a new release")
+	if _, _, err := EnsureLatestTemplates(context.Background()); err != nil {
+		t.Fatalf("third ensure: %v", err)
+	}
+	if *calls != 2 {
+		t.Errorf("installs = %d, want a fresh attempt on the new release", *calls)
+	}
+}
+
+// The live directory must hold a complete set at all times, never a half-written
+// one, so the download lands in a sibling and is swapped in.
+func TestInstallFreshSetDownloadsIntoStagingThenSwaps(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/old.yaml")
+
+	var sawLiveDirDuringDownload bool
+	freshInstall = func() error {
+		staging := config.DefaultConfig.TemplatesDirectory
+		if staging == dir {
+			sawLiveDirDuringDownload = true
+		}
+		// The previous set must still be complete while the new one downloads.
+		if _, err := os.Stat(filepath.Join(dir, "http/old.yaml")); err != nil {
+			t.Errorf("live template set was disturbed during the download: %v", err)
+		}
+		full := filepath.Join(staging, "http/new.yaml")
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(full, []byte("id: x\n"), 0o600)
+	}
+
+	if err := installFreshSet(); err != nil {
+		t.Fatalf("installFreshSet: %v", err)
+	}
+	if sawLiveDirDuringDownload {
+		t.Error("download wrote straight into the live directory")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "http/new.yaml")); err != nil {
+		t.Errorf("new set not swapped in: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "http/old.yaml")); err == nil {
+		t.Error("old set still present; the swap should have replaced it")
+	}
+	for _, glob := range []string{dir + ".incoming-*", dir + ".retired-*"} {
+		if leftovers, _ := filepath.Glob(glob); len(leftovers) != 0 {
+			t.Errorf("leftover dir: %v", leftovers)
+		}
+	}
+}
+
+func TestInstallFreshSetKeepsWorkingSetOnFailure(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/keep-me.yaml")
+	freshInstall = func() error { return errors.New("download failed") }
+
+	if err := installFreshSet(); err == nil {
+		t.Fatal("expected the download failure to surface")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "http/keep-me.yaml")); err != nil {
+		t.Errorf("working template set was lost on a failed download: %v", err)
+	}
+}
+
+// An empty download must never replace a working set.
+func TestInstallFreshSetRefusesEmptyDownload(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	writeTemplate(t, dir, "http/keep-me.yaml")
+	freshInstall = func() error { return os.MkdirAll(config.DefaultConfig.TemplatesDirectory, 0o755) }
+
+	err := installFreshSet()
+	if err == nil || !strings.Contains(err.Error(), "no templates") {
+		t.Fatalf("err = %v, want a refusal to swap an empty set", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "http/keep-me.yaml")); err != nil {
+		t.Errorf("working set was lost: %v", err)
+	}
+}
+
+// The staging path must not survive in nuclei's config, or the next boot looks
+// for a directory that was deleted.
+func TestInstallFreshSetRestoresConfiguredPath(t *testing.T) {
+	dir := stubTemplates(t, "v10.4.8")
+	installStub(t)
+
+	writes := 0
+	writeTemplatesConfig = func() error {
+		writes++
+		if got := config.DefaultConfig.TemplatesDirectory; got != dir {
+			t.Errorf("config written with %q, want the live path %q", got, dir)
+		}
+		return nil
+	}
+
+	if err := installFreshSet(); err != nil {
+		t.Fatalf("installFreshSet: %v", err)
+	}
+	if writes == 0 {
+		t.Error("nuclei's config was never rewritten with the live path")
+	}
+	if got := config.DefaultConfig.TemplatesDirectory; got != dir {
+		t.Errorf("TemplatesDirectory left at %q, want %q", got, dir)
+	}
+}
+
+// A template load holds the read lock; a repair must wait rather than swap the
+// directory out from under it.
+func TestRepairWaitsForAnInFlightTemplateLoad(t *testing.T) {
+	stubTemplates(t, "v10.4.8")
+	installStub(t)
+	fetchLatestTag = func(context.Context) (string, error) { return "v10.4.8", nil }
+
+	loading := make(chan struct{})
+	released := make(chan struct{})
+	go func() {
+		templateRW.RLock() // stands in for RunNuclei's load phase
+		close(loading)
+		<-released
+		templateRW.RUnlock()
+	}()
+	<-loading
+
+	RequestTemplateRepair("test")
+	done := make(chan struct{})
+	go func() {
+		_, _, _ = EnsureLatestTemplates(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("repair proceeded while a template load held the read lock")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(released)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair never completed after the load finished")
 	}
 }

--- a/pkg/scanlog/platform.go
+++ b/pkg/scanlog/platform.go
@@ -1,0 +1,122 @@
+package scanlog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/projectdiscovery/pd-agent/pkg/client"
+	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
+)
+
+// signedUploadResponse mirrors /v1/scans/{scan_id}/scan_log/upload-url.
+// Headers are authoritative: set them verbatim on the PUT and add nothing
+// else, since the SigV4 signature covers headers.
+type signedUploadResponse struct {
+	UploadURL  string            `json:"upload_url"`
+	Method     string            `json:"method"`
+	Headers    map[string]string `json:"headers"`
+	MaxBytes   int64             `json:"max_bytes"`
+	ObjectPath string            `json:"object_path"`
+	ExpiresAt  time.Time         `json:"expires_at"`
+}
+
+// PlatformUploader stores scan logs in ProjectDiscovery-managed storage.
+type PlatformUploader struct{}
+
+// NewPlatformUploader returns an uploader targeting PDCP-managed storage.
+func NewPlatformUploader() *PlatformUploader { return &PlatformUploader{} }
+
+// Name identifies the destination in logs.
+func (*PlatformUploader) Name() string { return "pdcp" }
+
+// Upload ships the gzipped scan log via:
+//  1. POST /v1/scans/{scan_id}/scan_log/upload-url?history_id=N with {"filename": ...}
+//  2. PUT the bytes to the signed URL with the response Headers verbatim.
+//
+// The payload is an opaque .gz blob (no Content-Encoding) so the SigV4 signed
+// headers never need to cover Content-Encoding; server gunzips on read.
+func (*PlatformUploader) Upload(ctx context.Context, m Meta, gzPath string, gzSize int64) (string, error) {
+	filename := m.ChunkID + ".jsonl.gz"
+	httpClient, err := client.CreateAuthenticatedClient(m.TeamID, envconfig.APIKey())
+	if err != nil {
+		return "", fmt.Errorf("auth client: %w", err)
+	}
+
+	reqBody, _ := json.Marshal(map[string]string{"filename": filename})
+	apiURL := fmt.Sprintf("%s/v1/scans/%s/scan_log/upload-url?history_id=%d",
+		envconfig.APIServer(), m.ScanID, m.HistoryID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("build upload-url request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get upload-url: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("upload-url status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var signed signedUploadResponse
+	if err := json.Unmarshal(respBody, &signed); err != nil {
+		return "", fmt.Errorf("decode upload-url response: %w", err)
+	}
+	if signed.UploadURL == "" || signed.Method == "" {
+		return "", fmt.Errorf("upload-url response missing url/method")
+	}
+	if signed.MaxBytes > 0 && gzSize > signed.MaxBytes {
+		return "", fmt.Errorf("gzipped output %d bytes exceeds signed-url max %d", gzSize, signed.MaxBytes)
+	}
+
+	f, err := os.Open(gzPath)
+	if err != nil {
+		return "", fmt.Errorf("open gz: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	putReq, err := http.NewRequestWithContext(ctx, signed.Method, signed.UploadURL, f)
+	if err != nil {
+		return "", fmt.Errorf("build PUT: %s", stripSignedURL(err))
+	}
+	putReq.ContentLength = gzSize
+	for k, v := range signed.Headers {
+		putReq.Header.Set(k, v)
+	}
+
+	putResp, err := http.DefaultClient.Do(putReq)
+	if err != nil {
+		return "", fmt.Errorf("PUT: %s", stripSignedURL(err))
+	}
+	defer func() { _ = putResp.Body.Close() }()
+
+	if putResp.StatusCode != http.StatusOK && putResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(putResp.Body)
+		return "", fmt.Errorf("PUT status %d: %s", putResp.StatusCode, string(body))
+	}
+	_, _ = io.Copy(io.Discard, putResp.Body)
+
+	return signed.ObjectPath, nil
+}
+
+// stripSignedURL drops the URL from a *url.Error so SigV4/GCS HMAC query
+// signatures never reach the logs. Keeps operation and underlying cause.
+func stripSignedURL(err error) string {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return fmt.Sprintf("%s: %s", ue.Op, ue.Err)
+	}
+	return err.Error()
+}

--- a/pkg/scanlog/platform_test.go
+++ b/pkg/scanlog/platform_test.go
@@ -1,4 +1,4 @@
-package pkg
+package scanlog
 
 import (
 	"compress/gzip"
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/projectdiscovery/pd-agent/pkg/types"
 )
 
 const testScanLogLine = `{"template-id":"test","host":"example.com","matched-at":"example.com:443"}` + "\n"
@@ -121,15 +119,17 @@ func writeOutput(t *testing.T, content string) string {
 	return path
 }
 
-func testTask() *types.Task {
-	return &types.Task{
-		Id: "chunk-abc123",
-		Options: types.Options{
-			TeamID:    "team-1",
-			ScanID:    "scan-9",
-			HistoryID: 42,
-		},
+func testMeta() Meta {
+	return Meta{
+		TeamID:    "team-1",
+		ScanID:    "scan-9",
+		ChunkID:   "chunk-abc123",
+		HistoryID: 42,
 	}
+}
+
+func uploadToPlatform(ctx context.Context, outputFile string) error {
+	return Upload(ctx, []Uploader{NewPlatformUploader()}, testMeta(), outputFile)
 }
 
 func gunzip(t *testing.T, b []byte) string {
@@ -146,12 +146,11 @@ func gunzip(t *testing.T, b []byte) string {
 	return string(out)
 }
 
-func TestUploadNucleiOutputViaSignedURL(t *testing.T) {
+func TestPlatformUploader(t *testing.T) {
 	srv := newScanLogServer(t)
 	outputFile := writeOutput(t, testScanLogLine)
-	task := testTask()
 
-	if err := uploadNucleiOutputViaSignedURL(context.Background(), task, outputFile); err != nil {
+	if err := uploadToPlatform(context.Background(), outputFile); err != nil {
 		t.Fatalf("upload: %v", err)
 	}
 
@@ -219,35 +218,7 @@ func TestUploadNucleiOutputViaSignedURL(t *testing.T) {
 	}
 }
 
-func TestUploadNucleiOutputViaSignedURLEmptyFile(t *testing.T) {
-	srv := newScanLogServer(t)
-	outputFile := writeOutput(t, "")
-
-	if err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile); err != nil {
-		t.Fatalf("upload: %v", err)
-	}
-	if n := len(srv.presigns()); n != 0 {
-		t.Errorf("presign requests = %d, want 0 for an empty output", n)
-	}
-	if n := len(srv.puts()); n != 0 {
-		t.Errorf("PUT requests = %d, want 0 for an empty output", n)
-	}
-}
-
-func TestUploadNucleiOutputViaSignedURLMissingFile(t *testing.T) {
-	newScanLogServer(t)
-	missing := filepath.Join(t.TempDir(), "absent.jsonl")
-
-	err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), missing)
-	if err == nil {
-		t.Fatal("expected an error for a missing output file")
-	}
-	if !strings.Contains(err.Error(), "stat output") {
-		t.Errorf("error = %v, want it to mention stat output", err)
-	}
-}
-
-func TestUploadNucleiOutputViaSignedURLPresignFailures(t *testing.T) {
+func TestPlatformUploaderPresignFailures(t *testing.T) {
 	tests := []struct {
 		name     string
 		response func(putURL string) (int, any)
@@ -290,7 +261,7 @@ func TestUploadNucleiOutputViaSignedURLPresignFailures(t *testing.T) {
 			srv.response = tt.response
 			outputFile := writeOutput(t, testScanLogLine)
 
-			err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+			err := uploadToPlatform(context.Background(), outputFile)
 			if err == nil {
 				t.Fatalf("expected an error containing %q", tt.wantErr)
 			}
@@ -304,7 +275,7 @@ func TestUploadNucleiOutputViaSignedURLPresignFailures(t *testing.T) {
 	}
 }
 
-func TestUploadNucleiOutputViaSignedURLPutStatus(t *testing.T) {
+func TestPlatformUploaderPutStatus(t *testing.T) {
 	tests := []struct {
 		name    string
 		code    int
@@ -324,7 +295,7 @@ func TestUploadNucleiOutputViaSignedURLPutStatus(t *testing.T) {
 			srv.putBody = tt.body
 			outputFile := writeOutput(t, testScanLogLine)
 
-			err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+			err := uploadToPlatform(context.Background(), outputFile)
 			switch {
 			case tt.wantErr == "" && err != nil:
 				t.Fatalf("upload: %v", err)
@@ -338,7 +309,7 @@ func TestUploadNucleiOutputViaSignedURLPutStatus(t *testing.T) {
 }
 
 // A transport failure must not put the signed URL's HMAC query into the error.
-func TestUploadNucleiOutputViaSignedURLDoesNotLeakSignature(t *testing.T) {
+func TestPlatformUploaderDoesNotLeakSignature(t *testing.T) {
 	const signature = "0123456789abcdefdeadbeef"
 
 	srv := newScanLogServer(t)
@@ -351,7 +322,7 @@ func TestUploadNucleiOutputViaSignedURLDoesNotLeakSignature(t *testing.T) {
 	}
 	outputFile := writeOutput(t, testScanLogLine)
 
-	err := uploadNucleiOutputViaSignedURL(context.Background(), testTask(), outputFile)
+	err := uploadToPlatform(context.Background(), outputFile)
 	if err == nil {
 		t.Fatal("expected a transport error")
 	}
@@ -407,47 +378,5 @@ func TestStripSignedURL(t *testing.T) {
 				t.Errorf("stripSignedURL() = %q, must not contain %q", got, tt.notWant)
 			}
 		})
-	}
-}
-
-func TestGzipFile(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "in.jsonl")
-	dst := filepath.Join(dir, "out.gz")
-
-	content := strings.Repeat(testScanLogLine, 200)
-	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	size, err := gzipFile(src, dst)
-	if err != nil {
-		t.Fatalf("gzipFile: %v", err)
-	}
-
-	st, err := os.Stat(dst)
-	if err != nil {
-		t.Fatalf("stat dst: %v", err)
-	}
-	if size != st.Size() {
-		t.Errorf("returned size = %d, want %d", size, st.Size())
-	}
-	if size >= int64(len(content)) {
-		t.Errorf("gz size %d not smaller than raw %d", size, len(content))
-	}
-
-	raw, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
-	}
-	if got := gunzip(t, raw); got != content {
-		t.Error("round-tripped content differs from source")
-	}
-}
-
-func TestGzipFileMissingSource(t *testing.T) {
-	dir := t.TempDir()
-	if _, err := gzipFile(filepath.Join(dir, "absent"), filepath.Join(dir, "out.gz")); err == nil {
-		t.Fatal("expected an error for a missing source")
 	}
 }

--- a/pkg/scanlog/scanlog.go
+++ b/pkg/scanlog/scanlog.go
@@ -1,0 +1,134 @@
+// Package scanlog ships raw per-chunk nuclei output (matched and unmatched)
+// to one or more storage destinations.
+package scanlog
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/projectdiscovery/pd-agent/pkg/envconfig"
+)
+
+// Meta identifies the chunk a scan log belongs to.
+type Meta struct {
+	TeamID    string
+	ScanID    string
+	ChunkID   string
+	HistoryID int64
+}
+
+// Uploader ships one gzipped scan log. Implementations receive an already
+// compressed file and return where the object landed.
+type Uploader interface {
+	Upload(ctx context.Context, m Meta, gzPath string, gzSize int64) (location string, err error)
+	Name() string
+}
+
+// Destinations resolves the configured upload targets. An empty slice means
+// scan-log upload is off.
+func Destinations() []Uploader {
+	var dests []Uploader
+	if envconfig.ScanLogUploadEnabled() {
+		dests = append(dests, NewPlatformUploader())
+	}
+	return dests
+}
+
+// Upload gzips outputFile once and ships it to every destination. An empty
+// output file is skipped without contacting any destination.
+func Upload(ctx context.Context, dests []Uploader, m Meta, outputFile string) error {
+	if len(dests) == 0 {
+		return nil
+	}
+
+	info, err := os.Stat(outputFile)
+	if err != nil {
+		return fmt.Errorf("stat output: %w", err)
+	}
+	if info.Size() == 0 {
+		slog.Debug("scan-log: output file empty, skipping upload",
+			"scan_id", m.ScanID, "chunk_id", m.ChunkID)
+		return nil
+	}
+
+	// Gzip into a sibling temp so we can stat for ContentLength. Unique name
+	// keeps a redelivered chunk from clobbering a still-uploading goroutine.
+	gzFile, err := os.CreateTemp(filepath.Dir(outputFile), filepath.Base(outputFile)+"-*.gz")
+	if err != nil {
+		return fmt.Errorf("create gz tempfile: %w", err)
+	}
+	gzPath := gzFile.Name()
+	_ = gzFile.Close()
+	defer func() { _ = os.Remove(gzPath) }()
+
+	gzSize, err := gzipFile(outputFile, gzPath)
+	if err != nil {
+		return fmt.Errorf("gzip output: %w", err)
+	}
+
+	slog.Debug("scan-log: gzipped output",
+		"scan_id", m.ScanID, "chunk_id", m.ChunkID,
+		"raw_bytes", info.Size(), "gz_bytes", gzSize)
+
+	var errs []error
+	for _, dest := range dests {
+		location, err := dest.Upload(ctx, m, gzPath, gzSize)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", dest.Name(), err))
+			continue
+		}
+		slog.Info("scan-log: output file uploaded",
+			"dest", dest.Name(),
+			"scan_id", m.ScanID,
+			"history_id", m.HistoryID,
+			"chunk_id", m.ChunkID,
+			"raw_bytes", info.Size(),
+			"gz_bytes", gzSize,
+			"location", location)
+	}
+
+	return errors.Join(errs...)
+}
+
+// gzipFile streams src through gzip into dst at BestSpeed (nuclei JSONL
+// compresses ~10x even at level 1) and returns the dst size.
+func gzipFile(src, dst string) (int64, error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return 0, fmt.Errorf("open src: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return 0, fmt.Errorf("create dst: %w", err)
+	}
+	gzw, err := gzip.NewWriterLevel(out, gzip.BestSpeed)
+	if err != nil {
+		_ = out.Close()
+		return 0, fmt.Errorf("gzip writer: %w", err)
+	}
+	if _, err := io.Copy(gzw, in); err != nil {
+		_ = gzw.Close()
+		_ = out.Close()
+		return 0, fmt.Errorf("gzip copy: %w", err)
+	}
+	if err := gzw.Close(); err != nil {
+		_ = out.Close()
+		return 0, fmt.Errorf("gzip close: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return 0, fmt.Errorf("close dst: %w", err)
+	}
+	st, err := os.Stat(dst)
+	if err != nil {
+		return 0, fmt.Errorf("stat dst: %w", err)
+	}
+	return st.Size(), nil
+}

--- a/pkg/scanlog/scanlog_test.go
+++ b/pkg/scanlog/scanlog_test.go
@@ -1,0 +1,180 @@
+package scanlog
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUploadEmptyFile(t *testing.T) {
+	srv := newScanLogServer(t)
+	outputFile := writeOutput(t, "")
+
+	if err := uploadToPlatform(context.Background(), outputFile); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if n := len(srv.presigns()); n != 0 {
+		t.Errorf("presign requests = %d, want 0 for an empty output", n)
+	}
+	if n := len(srv.puts()); n != 0 {
+		t.Errorf("PUT requests = %d, want 0 for an empty output", n)
+	}
+}
+
+func TestUploadMissingFile(t *testing.T) {
+	newScanLogServer(t)
+	missing := filepath.Join(t.TempDir(), "absent.jsonl")
+
+	err := uploadToPlatform(context.Background(), missing)
+	if err == nil {
+		t.Fatal("expected an error for a missing output file")
+	}
+	if !strings.Contains(err.Error(), "stat output") {
+		t.Errorf("error = %v, want it to mention stat output", err)
+	}
+}
+
+func TestGzipFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "in.jsonl")
+	dst := filepath.Join(dir, "out.gz")
+
+	content := strings.Repeat(testScanLogLine, 200)
+	if err := os.WriteFile(src, []byte(content), 0o600); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	size, err := gzipFile(src, dst)
+	if err != nil {
+		t.Fatalf("gzipFile: %v", err)
+	}
+
+	st, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat dst: %v", err)
+	}
+	if size != st.Size() {
+		t.Errorf("returned size = %d, want %d", size, st.Size())
+	}
+	if size >= int64(len(content)) {
+		t.Errorf("gz size %d not smaller than raw %d", size, len(content))
+	}
+
+	raw, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if got := gunzip(t, raw); got != content {
+		t.Error("round-tripped content differs from source")
+	}
+}
+
+func TestGzipFileMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := gzipFile(filepath.Join(dir, "absent"), filepath.Join(dir, "out.gz")); err == nil {
+		t.Fatal("expected an error for a missing source")
+	}
+}
+
+func TestDestinations(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		t.Setenv("PDCP_ENABLE_SCAN_LOG_UPLOAD", "")
+		if got := Destinations(); len(got) != 0 {
+			t.Errorf("Destinations() = %d, want 0 when the toggle is unset", len(got))
+		}
+	})
+
+	t.Run("platform when enabled", func(t *testing.T) {
+		t.Setenv("PDCP_ENABLE_SCAN_LOG_UPLOAD", "true")
+		got := Destinations()
+		if len(got) != 1 {
+			t.Fatalf("Destinations() = %d, want 1", len(got))
+		}
+		if got[0].Name() != "pdcp" {
+			t.Errorf("destination = %q, want pdcp", got[0].Name())
+		}
+	})
+}
+
+// fakeUploader records what the orchestrator handed it.
+type fakeUploader struct {
+	name    string
+	err     error
+	calls   int
+	gzBytes []byte
+	gzSize  int64
+}
+
+func (f *fakeUploader) Name() string { return f.name }
+
+func (f *fakeUploader) Upload(_ context.Context, _ Meta, gzPath string, gzSize int64) (string, error) {
+	f.calls++
+	f.gzSize = gzSize
+	f.gzBytes, _ = os.ReadFile(gzPath)
+	if f.err != nil {
+		return "", f.err
+	}
+	return "loc://" + f.name, nil
+}
+
+func TestUploadNoDestinations(t *testing.T) {
+	outputFile := writeOutput(t, testScanLogLine)
+	if err := Upload(context.Background(), nil, testMeta(), outputFile); err != nil {
+		t.Fatalf("Upload with no destinations: %v", err)
+	}
+}
+
+// One gzip, every destination, and a failing destination must not stop the rest.
+func TestUploadFansOutToEveryDestination(t *testing.T) {
+	a := &fakeUploader{name: "a"}
+	b := &fakeUploader{name: "b", err: errors.New("bucket on fire")}
+	c := &fakeUploader{name: "c"}
+	outputFile := writeOutput(t, testScanLogLine)
+
+	err := Upload(context.Background(), []Uploader{a, b, c}, testMeta(), outputFile)
+	if err == nil {
+		t.Fatal("expected the failing destination to surface an error")
+	}
+	if !strings.Contains(err.Error(), "b: bucket on fire") {
+		t.Errorf("error = %v, want it to name destination b", err)
+	}
+	if strings.Contains(err.Error(), "a:") || strings.Contains(err.Error(), "c:") {
+		t.Errorf("error = %v, must only name the failing destination", err)
+	}
+	for _, u := range []*fakeUploader{a, b, c} {
+		if u.calls != 1 {
+			t.Errorf("destination %s called %d times, want 1", u.name, u.calls)
+		}
+	}
+	if got := gunzip(t, a.gzBytes); got != testScanLogLine {
+		t.Errorf("destination a got %q, want the gzipped output", got)
+	}
+	if a.gzSize != int64(len(a.gzBytes)) {
+		t.Errorf("gzSize = %d, want %d", a.gzSize, len(a.gzBytes))
+	}
+	if string(a.gzBytes) != string(c.gzBytes) {
+		t.Error("destinations received different bytes; the output should be gzipped once")
+	}
+}
+
+func TestUploadRemovesGzTempOnFailure(t *testing.T) {
+	outputFile := writeOutput(t, testScanLogLine)
+	failing := &fakeUploader{name: "x", err: errors.New("nope")}
+
+	if err := Upload(context.Background(), []Uploader{failing}, testMeta(), outputFile); err == nil {
+		t.Fatal("expected an error")
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(outputFile))
+	if err != nil {
+		t.Fatalf("read output dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".gz") {
+			t.Errorf("leftover gz temp after a failed upload: %s", e.Name())
+		}
+	}
+}

--- a/pkg/validate/name.go
+++ b/pkg/validate/name.go
@@ -1,0 +1,61 @@
+// Package validate holds shared input checks for agent-supplied identifiers.
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// MaxNameLength is the longest accepted name, in characters.
+const MaxNameLength = 50
+
+var namePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// Name trims value and rejects it if empty, longer than MaxNameLength, or
+// containing anything outside [a-zA-Z0-9_-]. It returns the trimmed value.
+func Name(field, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if n := utf8.RuneCountInString(trimmed); n > MaxNameLength {
+		return "", fmt.Errorf("%s must be at most %d characters, got %d", field, MaxNameLength, n)
+	}
+	if !namePattern.MatchString(trimmed) {
+		return "", fmt.Errorf("%s must match %s", field, namePattern.String())
+	}
+	return trimmed, nil
+}
+
+// SanitizeName coerces value into a valid Name: first dot-separated label,
+// unsupported runs collapsed to "-", dashes trimmed, truncated to
+// MaxNameLength. Returns "" when nothing usable remains.
+func SanitizeName(value string) string {
+	label := strings.TrimSpace(value)
+	if i := strings.Index(label, "."); i > 0 {
+		label = label[:i]
+	}
+
+	var b strings.Builder
+	lastDash := false
+	for _, r := range label {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+			lastDash = r == '-'
+		default:
+			if b.Len() > 0 && !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+
+	out := strings.Trim(b.String(), "-")
+	if len(out) > MaxNameLength {
+		out = strings.Trim(out[:MaxNameLength], "-")
+	}
+	return out
+}

--- a/pkg/validate/name_test.go
+++ b/pkg/validate/name_test.go
@@ -1,8 +1,9 @@
 package validate
 
-import "strings"
-
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestName(t *testing.T) {
 	tests := []struct {

--- a/pkg/validate/name_test.go
+++ b/pkg/validate/name_test.go
@@ -1,0 +1,74 @@
+package validate
+
+import "strings"
+
+import "testing"
+
+func TestName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "alphanumeric", input: "prod1", want: "prod1"},
+		{name: "underscore and dash", input: "us_east-1", want: "us_east-1"},
+		{name: "trims surrounding space", input: "  default\n", want: "default"},
+		{name: "max length", input: strings.Repeat("a", MaxNameLength), want: strings.Repeat("a", MaxNameLength)},
+		{name: "empty", input: "", wantErr: true},
+		{name: "whitespace only", input: "   ", wantErr: true},
+		{name: "too long", input: strings.Repeat("a", MaxNameLength+1), wantErr: true},
+		{name: "inner space", input: "prod network", wantErr: true},
+		{name: "dot", input: "prod.network", wantErr: true},
+		{name: "slash", input: "prod/../etc", wantErr: true},
+		{name: "non-ascii", input: "prodé", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Name("agent-network", tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Name(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("Name(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "already valid", input: "pd-agent_1", want: "pd-agent_1"},
+		{name: "macos bonjour hostname", input: "MacBook-Pro-3.local", want: "MacBook-Pro-3"},
+		{name: "ec2 internal fqdn", input: "ip-10-0-1-5.ec2.internal", want: "ip-10-0-1-5"},
+		{name: "spaces", input: "My Box", want: "My-Box"},
+		{name: "collapses runs", input: "my   box!!!name", want: "my-box-name"},
+		{name: "trims edge dashes", input: " !box! ", want: "box"},
+		{name: "keeps existing dash run", input: "a--b", want: "a--b"},
+		{name: "truncates and trims", input: strings.Repeat("a", MaxNameLength) + "-tail", want: strings.Repeat("a", MaxNameLength)},
+		{name: "leading dot keeps whole value", input: ".hidden host", want: "hidden-host"},
+		{name: "all invalid", input: "..!!", want: ""},
+		{name: "non-ascii", input: "बॉक्स", want: ""},
+		{name: "empty", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeName(tt.input)
+			if got != tt.want {
+				t.Fatalf("SanitizeName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if got == "" {
+				return
+			}
+			if _, err := Name("agent-name", got); err != nil {
+				t.Errorf("SanitizeName(%q) = %q, not a valid name: %v", tt.input, got, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Agents could never move off the nuclei-templates release they booted with. Mine sat on `v10.4.5` from late June while upstream was `v10.4.8` — quietly skipping ~140 of this year's CVEs and reporting every scan as clean.

Three bugs stacked so that no agent could ever update:

- `InitNucleiProcess` calls `DisableUpdateCheck()`, a one-way process global that short-circuits `NeedsTemplateUpdate()`. The per-scan refresh added in `f2dd49b` was dead code that never ran once.
- Freshness compared the installed version against nuclei's **cached** "latest", which the SDK only refreshes at first engine init — after the code that could act on it. `v10.4.5` vs a June-cached `v10.4.5` read as up to date.
- Nothing ever checked whether the files were on disk.

And the log line said `"Nuclei templates are up to date"` whenever the update call returned nil, including when it had checked nothing. That is why this went unnoticed for two months.

## What changed

**Template freshness.** The agent resolves the real newest release from the GitHub API (TTL-cached, `GITHUB_TOKEN` honoured for the 5000/hr limit), compares by semver rather than string equality, and installs by staged swap: download into `<dir>.incoming-<pid>`, rename the old set aside, rename the new one in. `templateRW` makes that install the only writer — nuclei's own off-lock updater stays disabled — so a scan can never load a half-written directory. A full staged install measures ~6s, so incremental updates were dropped entirely.

**A missing template no longer produces a clean scan.** Chunks verify the templates they were actually given, via nuclei's own resolver (`disk.NewCatalog(...).GetTemplatesPath`) rather than a stat loop, which reported a glob as missing. An unresolvable template fails the chunk. `PDCP_REQUIRE_ALL_TEMPLATES=false` accepts partial coverage instead.

Repairs happen once at scan scope, not per chunk — the first version of this fix produced 8 full reinstalls for 8 chunks, each renaming the shared directory out from under its siblings mid-load.

**Boot no longer comes up on a broken set.** Fatality is decided by whether the agent holds a usable set, not by which step failed — an unreachable GitHub must not ground a fleet — but "usable" now means a plausible template count, not one file, so an interrupted download can't bring an agent up healthy.

**Agent name and network are validated** (required after trim, ≤50 chars, `^[a-zA-Z0-9_-]+$`), fail-fast at boot. Hostname-derived names are sanitized rather than rejected, since `os.Hostname()` routinely returns `MacBook-Pro-3.local`. A bad value from the server is logged and ignored rather than killing a running agent.

**Every heartbeat carries the agent version**, so the platform can record which build an agent is on without broadcasting a health-check RPC.

**Scan-log upload sits behind an `Uploader` interface** whose resolver returns a slice of destinations, so customer-owned storage can run alongside PD-hosted rather than replacing it. No behaviour change; the implementation lands separately.

## Breaking

- **`PDCP_REQUIRE_ALL_TEMPLATES` defaults to true.** A chunk with any unresolvable template now fails instead of silently scanning a subset. Nothing the agent reports carries the dropped count, so a partial scan was indistinguishable from a clean one — for a scanner, a false negative nobody can see is worse than a failed chunk.
- **Name validation is fail-fast.** An agent whose network name contains a dot or a space will self-update into this build and then refuse to start. Deliberate; those names were never routable.

## Testing

`go test ./...` green; `gofmt`, `go vet` clean; `go build` and `go build -race` clean; cross-compiles clean for linux, darwin and windows.

Opt-in live tests that exercise the real network and installer rather than a fake:

```
PD_TEST_TEMPLATES_LIVE=1 go test ./pkg/runtools/ -run Live -v
```

Two Windows failures are fixed here: `TestAnyPublic` used a `/tmp/...` literal as its absolute-path fixture, which `filepath.IsAbs` reports as relative on Windows; and four template tests failed in `t.TempDir`'s cleanup, not in the test body, because nuclei's disk catalog opens every candidate template and never closes it while Windows refuses to unlink a file with a live handle.

## Known and not fixed here

- `installFreshSet` derives its staging paths from the raw configured directory while `safeToReplace` validates the cleaned one, so a trailing slash makes staging a child of the live directory and every install fail permanently.
- The download ceiling is 15 minutes and the install ignores its context, so a scan-scope refresh can hold the template write lock far longer than a scan should tolerate.
- The missing `Close()` in nuclei's `findFileMatches` is upstream and also makes a staged install racy on Windows.
